### PR TITLE
targetBytecode must be set from maven.compiler.target property

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -80,7 +80,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * If an invalid selection is made, Groovy will default to VM determined
      * version.
      *
-     * @parameter default-value="1.5"
+     * @parameter property="maven.compiler.target" default-value="1.5"
      */
     protected String targetBytecode;
 


### PR DESCRIPTION
maven.compiler.target property is commonly used by the maven-compiler-plugin and others compilation plugins to set the bytecode compatibility target
