### PR TITLE
updated links in advancedGroovydoc pom to correct format

### DIFF
--- a/src/it/advancedGroovydoc/pom.xml
+++ b/src/it/advancedGroovydoc/pom.xml
@@ -99,9 +99,18 @@
           </sources>
           <stylesheetFile>src/main/resources/stylesheet.css</stylesheetFile>
           <links>
-            <link packages="java.,javax.,java.lang" href="http://docs.oracle.com/javase/5/docs/api/" />
-            <link packages="groovy.,org.codehaus.groovy." href="http://docs.groovy-lang.org/latest/html/api/" />
-            <link packages="org.junit.,junit.framework." href="http://junit.org/javadoc/latest/" />
+            <link>
+              <packages>java.,javax.,java.lang.</packages>
+              <href>http://docs.oracle.com/javase/5/docs/api/</href>
+            </link>
+            <link>
+              <packages>groovy.,org.codehaus.groovy.</packages>
+              <href>http://docs.groovy-lang.org/latest/html/api/</href>
+            </link>
+            <link>
+              <packages>org.junit.,junit.framework.</packages>
+              <href>http://junit.org/javadoc/latest/</href>
+            </link>
           </links>
         </configuration>
       </plugin>


### PR DESCRIPTION
This makes an update to the pom in src/it/advancedGroovydoc to change the links to the correct format. I had previously looked at the pom for an idea how to use the links parameter and copied what I found in there. That didn't work and you informed me of the correct form. So I thought it would be good to update the pom with correct usage for anyone else who might look to it for guidance in the future.