### PR TITLE
Fixed inconsistent 'groovyDoc'/'GroovyDoc' capitalization

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -159,7 +159,7 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
     protected String scope;
 
     /**
-     * Links to include in the generated groovyDoc (key is link href, value is
+     * Links to include in the generated GroovyDoc (key is link href, value is
      * comma-separated packages to use that link).
      * @since 1.0-beta-2
      *
@@ -168,7 +168,7 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
     protected List<Link> links;
 
     /**
-     * Whether to include Java sources in groovyDoc generation.
+     * Whether to include Java sources in GroovyDoc generation.
      * @since 1.0-beta-2
      *
      * @parameter default-value="true"


### PR DESCRIPTION
I was working on a branch and happened to look at both the Maven site groovydoc goal page for my snapshot and the 1.5 release and noticed that some of the inconsistent capitalization ('GroovyDoc', 'Groovydoc', 'groovydoc') on the 1.5 page had been fixed. I noticed a couple more inconsistencies and have fixed them.