### PR TITLE
Added parameter to allow for skipping of GroovyDoc generation

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -176,6 +176,14 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
     protected boolean groovyDocJavaSources;
 
     /**
+     * Flag to allow GroovyDoc generation to be skipped.
+     * @since 1.6
+     *
+     * @parameter property="maven.groovydoc.skip" default-value="false"
+     */
+    protected boolean skipGroovyDoc;
+
+    /**
      * Generates the GroovyDoc for the specified sources.
      *
      * @param sourceDirectories The source directories to generate groovyDoc for
@@ -191,6 +199,10 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
     protected synchronized void doGroovyDocGeneration(final FileSet[] sourceDirectories, final List classpath, final File outputDirectory) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, InstantiationException, MalformedURLException {
         classWrangler = new ClassWrangler(classpath, getLog());
 
+        if (skipGroovyDoc) {
+            getLog().info("Skipping generation of GroovyDoc because ${maven.groovydoc.skip} was set to true.");
+            return;
+        }
         if (sourceDirectories == null || sourceDirectories.length == 0) {
             getLog().info("No source directories specified for GroovyDoc generation.  Skipping.");
             return;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojoTest.java
@@ -1,0 +1,75 @@
+package org.codehaus.gmavenplus.mojo;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.shared.model.fileset.util.FileSetManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.io.File;
+import java.util.Properties;
+
+import static java.util.Collections.emptyList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the AbstractGroovyDocMojo class.
+ *
+ * @author Rick Venutolo
+ */
+public class AbstractGroovyDocMojoTest {
+    @Spy
+    private TestMojo testMojo;
+
+    @Mock
+    private MojoExecution mojoExecution;
+
+    @Mock
+    private MojoDescriptor mojoDescriptor;
+
+    @Mock
+    private MavenProject project;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        testMojo.mojoExecution = mojoExecution;
+        doReturn(mojoDescriptor).when(mojoExecution).getMojoDescriptor();
+        testMojo.project = project;
+        doReturn(new Properties()).when(testMojo).setupProperties();
+        doReturn(emptyList()).when(testMojo).setupGroovyDocSources(any(FileSet[].class), any(FileSetManager.class));
+        doNothing().when(testMojo).generateGroovyDoc(any(File.class), any(Class.class), any(Class.class), anyObject(), anyListOf(String.class), anyObject());
+    }
+
+    @Test
+    public void testDontSkipGroovyDoc() throws Exception {
+        testMojo.doGroovyDocGeneration(new FileSet[]{new FileSet()}, emptyList(), new File(""));
+        verify(testMojo, times(1)).generateGroovyDoc(any(File.class), any(Class.class), any(Class.class), anyObject(), anyListOf(String.class), anyObject());
+    }
+
+    @Test
+    public void testSkipGroovyDoc() throws Exception {
+        testMojo.skipGroovyDoc = true;
+        testMojo.doGroovyDocGeneration(new FileSet[]{new FileSet()}, emptyList(), new File(""));
+        verify(testMojo, never()).generateGroovyDoc(any(File.class), any(Class.class), any(Class.class), anyObject(), anyListOf(String.class), anyObject());
+    }
+
+    public static class TestMojo extends AbstractGroovyDocMojo {
+        public void execute() throws MojoExecutionException, MojoFailureException { }
+    }
+
+}


### PR DESCRIPTION
I have added a ```skipGroovyDoc``` parameter to the ```groovydoc``` goal to allow for skipping of GroovyDoc generation.

One can do something similar for the Maven Javadoc plugin [by setting the plugin's ```skip``` parameter or by setting the ```maven.javadoc.skip``` user property](http://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#skip). I thought something similar would be nice to have in this plugin, like for a Travis install (the default install step includes ```-Dmaven.javadoc.skip=true```).

If this does interest you, then you may want to choose a different parameter name than ```skipGroovyDoc``` and a different user property than ```maven.groovydoc.skip```.
