### PR TITLE
Fixed NPE when calling mojo without Groovy dependency

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -165,13 +165,13 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
             throws ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException, MalformedURLException {
         classWrangler = new ClassWrangler(classpath, getLog());
 
-        logPluginClasspath();
-        classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
-
         if (sources == null || sources.isEmpty()) {
             getLog().info("No sources specified for compilation.  Skipping.");
             return;
         }
+
+        logPluginClasspath();
+        classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
 
         if (groovyVersionSupportsAction()) {
             verifyGroovyVersionSupportsTargetBytecode();

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -140,13 +140,13 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected synchronized void doStubGeneration(final Set<File> stubSources, final List classpath, final File outputDirectory) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, InstantiationException, MalformedURLException {
         classWrangler = new ClassWrangler(classpath, getLog());
 
-        logPluginClasspath();
-        classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
-
         if (stubSources == null || stubSources.isEmpty()) {
             getLog().info("No sources specified for stub generation.  Skipping.");
             return;
         }
+
+        logPluginClasspath();
+        classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
 
         if (!groovyVersionSupportsAction()) {
             getLog().error("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support stub generation.  The minimum version of Groovy required is " + minGroovyVersion + ".  Skipping stub generation.");

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -191,13 +191,16 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
             getLog().info("Skipping generation of GroovyDoc because ${maven.groovydoc.skip} was set to true.");
             return;
         }
+
         if (sourceDirectories == null || sourceDirectories.length == 0) {
             getLog().info("No source directories specified for GroovyDoc generation.  Skipping.");
             return;
         }
+
+        classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
+        logPluginClasspath();
+
         if (groovyVersionSupportsAction()) {
-            classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
-            logPluginClasspath();
             try {
                 getLog().debug("Project compile classpath:\n" + project.getCompileClasspathElements());
             } catch (DependencyResolutionRequiredException e) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -61,6 +61,7 @@ public class ConsoleMojo extends AbstractToolsMojo {
 
         logPluginClasspath();
         classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
+
         try {
             getLog().debug("Project test classpath:\n" + project.getTestClasspathElements());
         } catch (DependencyResolutionRequiredException e) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -95,8 +95,14 @@ public class ExecuteMojo extends AbstractToolsMojo {
     protected synchronized void doExecute() throws MojoExecutionException, MojoFailureException {
         classWrangler = new ClassWrangler(Thread.currentThread().getContextClassLoader(), getLog());
 
+        if (scripts == null || scripts.length == 0) {
+            getLog().info("No scripts specified for execution.  Skipping.");
+            return;
+        }
+
         logPluginClasspath();
         classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
+
         try {
             getLog().debug("Project test classpath:\n" + project.getTestClasspathElements());
         } catch (DependencyResolutionRequiredException e) {
@@ -104,11 +110,6 @@ public class ExecuteMojo extends AbstractToolsMojo {
         }
 
         if (groovyVersionSupportsAction()) {
-            if (scripts == null || scripts.length == 0) {
-                getLog().info("No scripts specified for execution.  Skipping.");
-                return;
-            }
-
             final SecurityManager sm = System.getSecurityManager();
             try {
                 if (!allowSystemExits) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -73,6 +73,7 @@ public class ShellMojo extends AbstractToolsMojo {
 
         logPluginClasspath();
         classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
+
         try {
             getLog().debug("Project test classpath:\n" + project.getTestClasspathElements());
         } catch (DependencyResolutionRequiredException e) {


### PR DESCRIPTION
Fixed that logging Groovy version before checking whether the mojo will do any work can cause an NPE if Groovy isn't available in the module