### PR TITLE
Make order of collected files reproducible

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
@@ -50,8 +50,8 @@ public abstract class AbstractGroovySourcesMojo extends AbstractGroovyMojo {
      * @param includeJavaSources Whether to include Java sources
      * @return The included files from the specified sources
      */
-    protected Set<File> getFiles(final FileSet[] fromSources, final boolean includeJavaSources) {
-        Set<File> files = new HashSet<File>();
+    protected SortedSet<File> getFiles(final FileSet[] fromSources, final boolean includeJavaSources) {
+        SortedSet<File> files = new TreeSet<File>();
         FileSetManager fileSetManager = new FileSetManager(getLog());
 
         for (FileSet fileSet : getFilesets(fromSources, includeJavaSources)) {
@@ -70,8 +70,8 @@ public abstract class AbstractGroovySourcesMojo extends AbstractGroovyMojo {
      * @param includeJavaSources Whether to include Java sources
      * @return The included files from the specified sources
      */
-    protected Set<File> getTestFiles(final FileSet[] fromSources, final boolean includeJavaSources) {
-        Set<File> files = new HashSet<File>();
+    protected SortedSet<File> getTestFiles(final FileSet[] fromSources, final boolean includeJavaSources) {
+        SortedSet<File> files = new TreeSet<File>();
         FileSetManager fileSetManager = new FileSetManager(getLog());
 
         for (FileSet fileSet : getTestFilesets(fromSources, includeJavaSources)) {

--- a/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
@@ -31,8 +31,8 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +51,7 @@ public class CompileMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Set<File> sources = new HashSet<File>();
+        Set<File> sources = new TreeSet<File>();
         sources.add(mock(File.class));
         doReturn(sources).when(compileMojo).getTestFiles(any(FileSet[].class), eq(false));
         compileMojo.outputDirectory = mock(File.class);

--- a/src/test/java/org/codehaus/gmavenplus/mojo/CompileTestsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/CompileTestsMojoTest.java
@@ -31,8 +31,8 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +51,7 @@ public class CompileTestsMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Set<File> sources = new HashSet<File>();
+        Set<File> sources = new TreeSet<File>();
         sources.add(mock(File.class));
         doReturn(sources).when(compileTestsMojo).getTestFiles(any(FileSet[].class), eq(false));
         compileTestsMojo.testOutputDirectory = mock(File.class);

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
@@ -31,7 +31,7 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +50,8 @@ public class GenerateStubsMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        doReturn(new HashSet<File>()).when(generateStubsMojo).getFiles(any(FileSet[].class), eq(false));
-        doReturn(new HashSet<File>()).when(generateStubsMojo).getStubs(any(File.class));
+        doReturn(new TreeSet<File>()).when(generateStubsMojo).getFiles(any(FileSet[].class), eq(false));
+        doReturn(new TreeSet<File>()).when(generateStubsMojo).getStubs(any(File.class));
         generateStubsMojo.project = mock(MavenProject.class);
         generateStubsMojo.stubsOutputDirectory = mock(File.class);
         doReturn(mock(Build.class)).when(generateStubsMojo.project).getBuild();

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojoTest.java
@@ -31,7 +31,7 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +50,8 @@ public class GenerateTestStubsMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        doReturn(new HashSet<File>()).when(generateTestStubsMojo).getTestFiles(any(FileSet[].class), eq(false));
-        doReturn(new HashSet<File>()).when(generateTestStubsMojo).getStubs(any(File.class));
+        doReturn(new TreeSet<File>()).when(generateTestStubsMojo).getTestFiles(any(FileSet[].class), eq(false));
+        doReturn(new TreeSet<File>()).when(generateTestStubsMojo).getStubs(any(File.class));
         generateTestStubsMojo.project = mock(MavenProject.class);
         generateTestStubsMojo.testStubsOutputDirectory = mock(File.class);
         doReturn(mock(Build.class)).when(generateTestStubsMojo.project).getBuild();

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocMojoTest.java
@@ -30,8 +30,8 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,7 +50,7 @@ public class GroovyDocMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Set<File> sources = new HashSet<File>();
+        Set<File> sources = new TreeSet<File>();
         sources.add(mock(File.class));
         doReturn(sources).when(groovyDocMojo).getTestFiles(any(FileSet[].class), eq(false));
         groovyDocMojo.groovyDocOutputDirectory = mock(File.class);

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojoTest.java
@@ -30,8 +30,8 @@ import org.mockito.Spy;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,7 +50,7 @@ public class GroovyDocTestsMojoTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        Set<File> sources = new HashSet<File>();
+        Set<File> sources = new TreeSet<File>();
         sources.add(mock(File.class));
         doReturn(sources).when(groovyDocTestsMojo).getTestFiles(any(FileSet[].class), eq(false));
         groovyDocTestsMojo.testGroovyDocOutputDirectory = mock(File.class);


### PR DESCRIPTION
The output of the Groovy depends on the order of source files, e.g. when
generating stubs for a class and its superclass, `implements
GroovyObject` will be added to the class only if the superclass hasn't
already been processed. Therefore, this commit orders the files
lexicographically to make the output reproducible.

Please let me know, if this warrants an (integration) test. If so, I'll
need a few instructions where to add it.