### PR TITLE
Support for Java 14 and option to skip bytecode check (#152)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.codehaus.gmavenplus</groupId>
   <artifactId>gmavenplus-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.8.2-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -155,6 +155,14 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
     protected String targetBytecode;
 
     /**
+     * Whether to check that the version of Groovy used is able to use the requested <code>targetBytecode</code>.
+     *
+     * @since 1.9.0
+     */
+    @Parameter(property = "skipBytecodeCheck", defaultValue = "false")
+    protected boolean skipBytecodeCheck;
+
+    /**
      * Whether Groovy compiler should be set to debug.
      */
     @Parameter(defaultValue = "false")
@@ -256,7 +264,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         logPluginClasspath();
         classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
 
-        if (groovyVersionSupportsAction()) {
+        if (groovyVersionSupportsAction() && !skipBytecodeCheck) {
             verifyGroovyVersionSupportsTargetBytecode();
         } else {
             getLog().error("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support compilation. The minimum version of Groovy required is " + minGroovyVersion + ". Skipping compiling.");

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -41,6 +41,11 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.*;
 public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
     /**
+     * Groovy 3.0.0 beta-2 version.
+     */
+    protected static final Version GROOVY_3_0_0_BETA2 = new Version(3, 0, 0, "beta-2");
+
+    /**
      * Groovy 3.0.0 beta-1 version.
      */
     protected static final Version GROOVY_3_0_0_BETA1 = new Version(3, 0, 0, "beta-1");
@@ -129,6 +134,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      *   <li>11</li>
      *   <li>12</li>
      *   <li>13</li>
+     *   <li>14</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -136,6 +142,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * Using 9 with invokedynamic requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 2, but not any 2.6 versions.
      * Using 10, 11, or 12 requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 4, but not any 2.6 versions.
      * Using 13 requires Groovy &gt;= 2.5.7, or Groovy &gt;= 3.0.0-beta-1, but not any 2.6 versions.
+     * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
      */
     @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
     protected String targetBytecode;
@@ -396,7 +403,11 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("13".equals(targetBytecode)) {
+        if ("14".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_0_BETA2)) {
+                throw new IllegalArgumentException("Target bytecode 14 requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
+            }
+        } else if ("13".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_5_7) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_BETA1))) {
                 throw new IllegalArgumentException("Target bytecode 13 requires Groovy " + GROOVY_2_5_7 + "/" + GROOVY_3_0_0_BETA1 + " or newer. No 2.6 version is supported.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -41,6 +41,11 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.*;
 public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
     /**
+     * Groovy 3.0.3 version.
+     */
+    protected static final Version GROOVY_3_0_3 = new Version(3, 0, 3);
+
+    /**
      * Groovy 3.0.0 beta-2 version.
      */
     protected static final Version GROOVY_3_0_0_BETA2 = new Version(3, 0, 0, "beta-2");
@@ -135,6 +140,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      *   <li>12</li>
      *   <li>13</li>
      *   <li>14</li>
+     *   <li>15</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -143,6 +149,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * Using 10, 11, or 12 requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 4, but not any 2.6 versions.
      * Using 13 requires Groovy &gt;= 2.5.7, or Groovy &gt;= 3.0.0-beta-1, but not any 2.6 versions.
      * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
+     * Using 15 requires Groovy &gt;= 3.0.3.
      */
     @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
     protected String targetBytecode;
@@ -403,7 +410,11 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("14".equals(targetBytecode)) {
+        if ("15".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_3)) {
+                throw new IllegalArgumentException("Target bytecode 15 requires Groovy " + GROOVY_3_0_3 + " or newer.");
+            }
+        } else if ("14".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_0_BETA2)) {
                 throw new IllegalArgumentException("Target bytecode 14 requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -45,6 +45,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      */
 
     /**
+     * Groovy 3.0.0 beta-2 version.
+     */
+    protected static final Version GROOVY_3_0_0_BETA2 = new Version(3, 0, 0, "beta-2");
+
+    /**
      * Groovy 3.0.0 beta-1 version.
      */
     protected static final Version GROOVY_3_0_0_BETA1 = new Version(3, 0, 0, "beta-1");
@@ -133,6 +138,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      *   <li>11</li>
      *   <li>12</li>
      *   <li>13</li>
+     *   <li>14</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -140,6 +146,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * Using 9 with invokedynamic requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 2, but not any 2.6 versions.
      * Using 10, 11, or 12 requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 4, but not any 2.6 versions.
      * Using 13 requires Groovy &gt;= 2.5.7, or Groovy &gt;= 3.0.0-beta-1, but not any 2.6 versions.
+     * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
      *
      * @since 1.0-beta-3
      */
@@ -364,7 +371,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("13".equals(targetBytecode)) {
+        if ("14".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_0_BETA2)) {
+                throw new IllegalArgumentException("Target bytecode 14 requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
+            }
+        } else if ("13".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_5_7) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_BETA1))) {
                 throw new IllegalArgumentException("Target bytecode 13 requires Groovy " + GROOVY_2_5_7 + "/" + GROOVY_3_0_0_BETA1 + " or newer. No 2.6 version is supported.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -45,6 +45,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      */
 
     /**
+     * Groovy 3.0.3 version.
+     */
+    protected static final Version GROOVY_3_0_3 = new Version(3, 0, 3);
+
+    /**
      * Groovy 3.0.0 beta-2 version.
      */
     protected static final Version GROOVY_3_0_0_BETA2 = new Version(3, 0, 0, "beta-2");
@@ -139,6 +144,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      *   <li>12</li>
      *   <li>13</li>
      *   <li>14</li>
+     *   <li>15</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -147,6 +153,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * Using 10, 11, or 12 requires Groovy &gt;= 2.5.3, or Groovy &gt;= 3.0.0 alpha 4, but not any 2.6 versions.
      * Using 13 requires Groovy &gt;= 2.5.7, or Groovy &gt;= 3.0.0-beta-1, but not any 2.6 versions.
      * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
+     * Using 15 requires Groovy &gt;= 3.0.3.
      *
      * @since 1.0-beta-3
      */
@@ -371,7 +378,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("14".equals(targetBytecode)) {
+        if ("15".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_3)) {
+                throw new IllegalArgumentException("Target bytecode 15 requires Groovy " + GROOVY_3_0_3 + " or newer.");
+            }
+        } else if ("14".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_0_BETA2)) {
                 throw new IllegalArgumentException("Target bytecode 14 requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -161,6 +161,14 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected String targetBytecode;
 
     /**
+     * Whether to check that the version of Groovy used is able to use the requested <code>targetBytecode</code>.
+     *
+     * @since 1.9.0
+     */
+    @Parameter(property = "skipBytecodeCheck", defaultValue = "false")
+    protected boolean skipBytecodeCheck;
+
+    /**
      * Whether Groovy compiler should be set to debug.
      */
     @Parameter(defaultValue = "false")
@@ -240,7 +248,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
         logPluginClasspath();
         classWrangler.logGroovyVersion(mojoExecution.getMojoDescriptor().getGoal());
 
-        if (groovyVersionSupportsAction()) {
+        if (groovyVersionSupportsAction() && !skipBytecodeCheck) {
             verifyGroovyVersionSupportsTargetBytecode();
         } else {
             getLog().error("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support stub generation. The minimum version of Groovy required is " + minGroovyVersion + ". Skipping stub generation.");

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -137,7 +137,7 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
      *
      * @since 1.6
      */
-    @Parameter(property = "maven.groovydoc.skip", defaultValue = "false")
+    @Parameter(property = "skipGroovydoc", defaultValue = "false")
     protected boolean skipGroovyDoc;
 
     /**
@@ -168,7 +168,7 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
      */
     protected synchronized void doGroovyDocGeneration(final FileSet[] sourceDirectories, final List<?> classpath, final File outputDirectory) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, InstantiationException, MalformedURLException {
         if (skipGroovyDoc) {
-            getLog().info("Skipping generation of GroovyDoc because ${maven.groovydoc.skip} was set to true.");
+            getLog().info("Skipping generation of GroovyDoc because ${skipGroovydoc} was set to true.");
             return;
         }
 

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -293,6 +293,20 @@ public class AbstractCompileMojoTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testJava15WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.2");
+        testMojo.targetBytecode = "15";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava15WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.3");
+        testMojo.targetBytecode = "15";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");
         testMojo.targetBytecode = "unknown";

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -279,6 +279,20 @@ public class AbstractCompileMojoTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testJava14WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.0-beta-1");
+        testMojo.targetBytecode = "14";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava14WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.0-beta-2");
+        testMojo.targetBytecode = "14";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");
         testMojo.targetBytecode = "unknown";

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -328,6 +328,20 @@ public class AbstractGenerateStubsMojoTest {
         testMojo.verifyGroovyVersionSupportsTargetBytecode();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testJava15WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.2");
+        testMojo.targetBytecode = "15";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava15WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.3");
+        testMojo.targetBytecode = "15";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
     protected static class TestMojo extends AbstractGenerateStubsMojo {
         protected TestMojo() {
             this(GROOVY_1_8_2.toString(), false);

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -314,6 +314,20 @@ public class AbstractGenerateStubsMojoTest {
         testMojo.verifyGroovyVersionSupportsTargetBytecode();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testJava14WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.0-beta-1");
+        testMojo.targetBytecode = "14";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava14WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.0-beta-2");
+        testMojo.targetBytecode = "14";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
     protected static class TestMojo extends AbstractGenerateStubsMojo {
         protected TestMojo() {
             this(GROOVY_1_8_2.toString(), false);


### PR DESCRIPTION
Also renames "maven.groovydoc.skip" property to "skipGroovydoc" so it matches the pattern of the other properties and won't seem to imply it's a property for a standard Maven plugin.

https://github.com/apache/groovy/commit/8c34cacc37e55a9264e56182ff9eedd186312704, which [adds Java 15 support](https://issues.apache.org/jira/browse/GROOVY-9377), wasn't on the GROOVY_3_0_X branch, until I [cherry-picked](https://github.com/apache/groovy/commit/511295f507ff07c311483a3f64d78870ccaf4875) it over. It should arrive in Groovy 3.0.3.  I've also added a check in anticipation of this.