### PR TITLE
Fix debug output of plugin class path

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
@@ -112,9 +112,11 @@ public abstract class AbstractGroovyMojo extends AbstractMojo {
     protected void logPluginClasspath() {
         if (getLog().isDebugEnabled()) {
             StringBuilder sb = new StringBuilder();
-            for (Artifact artifact : pluginArtifacts) {
-                sb.append(artifact.getFile());
-                sb.append(", ");
+            for (int i = 0; i < pluginArtifacts.size(); i++) {
+                sb.append(pluginArtifacts.get(i).getFile());
+                if (i < pluginArtifacts.size() - 1) {
+                    sb.append(", ");
+                }
             }
             getLog().debug("Plugin classpath:\n" + sb.toString());
         }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
@@ -114,6 +114,7 @@ public abstract class AbstractGroovyMojo extends AbstractMojo {
             StringBuilder sb = new StringBuilder();
             for (Artifact artifact : pluginArtifacts) {
                 sb.append(artifact.getFile());
+                sb.append(", ");
             }
             getLog().debug("Plugin classpath:\n" + sb.toString());
         }


### PR DESCRIPTION
Just a minor nit: Before, there was no separator between elements, with this naive change there is one too much at the end...