### PR TITLE
Allow Java 17 as target bytecode

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -41,9 +41,19 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.*;
 public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
     /**
+     * Groovy 4.0.0 alpha-3 version.
+     */
+    protected static final Version GROOVY_4_0_0_ALPHA3 = new Version(4, 0, 0, "alpha-3");
+
+    /**
      * Groovy 4.0.0 alpha-1 version.
      */
     protected static final Version GROOVY_4_0_0_ALPHA1 = new Version(4, 0, 0, "alpha-1");
+
+    /**
+     * Groovy 3.0.9 version.
+     */
+    protected static final Version GROOVY_3_0_8 = new Version(3, 0, 8);
 
     /**
      * Groovy 3.0.6 version.
@@ -157,6 +167,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      *   <li>14</li>
      *   <li>15</li>
      *   <li>16</li>
+     *   <li>17</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -167,6 +178,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
      * Using 15 requires Groovy &gt;= 3.0.3.
      * Using 16 requires Groovy &gt;= 3.0.6.
+     * Using 17 requires Groovy &gt;= 3.0.8 or Groovy &gt; 4.0.0-alpha-3.
      */
     @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
     protected String targetBytecode;
@@ -477,7 +489,11 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("16".equals(targetBytecode)) {
+        if ("17".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_8) || (groovyAtLeast(GROOVY_4_0_0_ALPHA1) && groovyOlderThan(GROOVY_4_0_0_ALPHA3))) {
+                throw new IllegalArgumentException("Target bytecode 17 requires Groovy " + GROOVY_3_0_8 + "/" + GROOVY_4_0_0_ALPHA3 + " or newer.");
+            }
+        } else if ("16".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_6)) {
                 throw new IllegalArgumentException("Target bytecode 16 requires Groovy " + GROOVY_3_0_6 + " or newer.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -45,6 +45,21 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      */
 
     /**
+     * Groovy 4.0.0 alpha-3 version.
+     */
+    protected static final Version GROOVY_4_0_0_ALPHA3 = new Version(4, 0, 0, "alpha-3");
+
+    /**
+     * Groovy 4.0.0 alpha-1 version.
+     */
+    protected static final Version GROOVY_4_0_0_ALPHA1 = new Version(4, 0, 0, "alpha-1");
+
+    /**
+     * Groovy 3.0.9 version.
+     */
+    protected static final Version GROOVY_3_0_8 = new Version(3, 0, 8);
+
+    /**
      * Groovy 3.0.6 version.
      */
     protected static final Version GROOVY_3_0_6 = new Version(3, 0, 6);
@@ -151,6 +166,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      *   <li>14</li>
      *   <li>15</li>
      *   <li>16</li>
+     *   <li>17</li>
      * </ul>
      * Using 1.6 or 1.7 requires Groovy &gt;= 2.1.3.
      * Using 1.8 requires Groovy &gt;= 2.3.3.
@@ -161,6 +177,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * Using 14 requires Groovy &gt;= 3.0.0 beta-2.
      * Using 15 requires Groovy &gt;= 3.0.3.
      * Using 16 requires Groovy &gt;= 3.0.6.
+     * Using 17 requires Groovy &gt;= 3.0.8 or Groovy &gt; 4.0.0-alpha-3.
      *
      * @since 1.0-beta-3
      */
@@ -381,7 +398,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("16".equals(targetBytecode)) {
+        if ("17".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_3_0_8) || (groovyAtLeast(GROOVY_4_0_0_ALPHA1) && groovyOlderThan(GROOVY_4_0_0_ALPHA3))) {
+                throw new IllegalArgumentException("Target bytecode 17 requires Groovy " + GROOVY_3_0_8 + "/" + GROOVY_4_0_0_ALPHA3 + " or newer.");
+            }
+        } else if ("16".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_6)) {
                 throw new IllegalArgumentException("Target bytecode 16 requires Groovy " + GROOVY_3_0_6 + " or newer.");
             }

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -321,6 +321,34 @@ public class AbstractCompileMojoTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testJava17WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.7");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava17WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.8");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testJava17WithUnsupportedGroovy4() {
+        testMojo = new TestMojo("4.0.0-alpha-2");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava17WithSupportedGroovy4() {
+        testMojo = new TestMojo("4.0.0-alpha-3");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");
         testMojo.targetBytecode = "unknown";

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -357,6 +357,34 @@ public class AbstractGenerateStubsMojoTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testJava17WithUnsupportedGroovy() {
+        testMojo = new TestMojo("3.0.7");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava17WithSupportedGroovy() {
+        testMojo = new TestMojo("3.0.8");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testJava17WithUnsupportedGroovy4() {
+        testMojo = new TestMojo("4.0.0-alpha-2");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test
+    public void testJava17WithSupportedGroovy4() {
+        testMojo = new TestMojo("4.0.0-alpha-3");
+        testMojo.targetBytecode = "17";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");
         testMojo.targetBytecode = "unknown";


### PR DESCRIPTION
I don't know if Groovy 3.0.9 is fully or first compatible version with Java 17. I have tested with a Java project and at least Spock tests are running.