### PR TITLE
Revert "Remove team from Maven site"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -645,6 +645,15 @@
   <description>Integrates Groovy into Maven projects.</description>
   <inceptionYear>2011</inceptionYear>
   <url>http://groovy.github.io/GMavenPlus/</url>
+  <developers>
+    <developer>
+      <id>keeganwitt</id>
+      <name>Keegan Witt</name>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
+  </developers>
   <licenses>
     <license>
       <name>Apache 2</name>


### PR DESCRIPTION
This reverts commit 56b5a9ae4fc0a7b6b1c1e3a0d36c27e6818c6552.

Apparently having this is a requirement of Central syncing. I got this error message while closing the staging repo in Sonatype OSS.
> Invalid POM: /org/codehaus/gmavenplus/gmavenplus-plugin/1.13.0/gmavenplus-plugin-1.13.0.pom: Developer information missing