### PR TITLE
Support bytecode 5, 6, 7, 8, and 1.9 args (closes #223)

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.security.CodeSource;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -347,6 +348,16 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         }
     }
 
+    private static String translateJavacTargetToTargetBytecode(String targetBytecode) {
+        Map<String, String> javacTargetToTargetBytecode = new HashMap<>();
+        javacTargetToTargetBytecode.put("5", "1.5");
+        javacTargetToTargetBytecode.put("6", "1.6");
+        javacTargetToTargetBytecode.put("7", "1.7");
+        javacTargetToTargetBytecode.put("8", "1.8");
+        javacTargetToTargetBytecode.put("1.9", "9");
+        return javacTargetToTargetBytecode.getOrDefault(targetBytecode, targetBytecode);
+    }
+
     /**
      * Sets up the CompilationUnit to use for compilation.
      *
@@ -429,7 +440,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         invokeMethod(findMethod(compilerConfigurationClass, "setVerbose", boolean.class), compilerConfiguration, verbose);
         invokeMethod(findMethod(compilerConfigurationClass, "setWarningLevel", int.class), compilerConfiguration, warningLevel);
         invokeMethod(findMethod(compilerConfigurationClass, "setTolerance", int.class), compilerConfiguration, tolerance);
-        invokeMethod(findMethod(compilerConfigurationClass, "setTargetBytecode", String.class), compilerConfiguration, targetBytecode);
+        invokeMethod(findMethod(compilerConfigurationClass, "setTargetBytecode", String.class), compilerConfiguration, translateJavacTargetToTargetBytecode(targetBytecode));
         if (previewFeatures) {
             if (isJavaSupportPreviewFeatures()) {
                 if (groovyOlderThan(GROOVY_2_5_7) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_BETA1))) {
@@ -515,49 +526,49 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
     protected void verifyGroovyVersionSupportsTargetBytecode() {
         if ("18".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_4_0_0_BETA1)) {
-                throw new IllegalArgumentException("Target bytecode 18 requires Groovy " + GROOVY_4_0_0_BETA1 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_4_0_0_BETA1 + " or newer.");
             }
         } else if ("17".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_8) || (groovyAtLeast(GROOVY_4_0_0_ALPHA1) && groovyOlderThan(GROOVY_4_0_0_ALPHA3))) {
-                throw new IllegalArgumentException("Target bytecode 17 requires Groovy " + GROOVY_3_0_8 + "/" + GROOVY_4_0_0_ALPHA3 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_3_0_8 + "/" + GROOVY_4_0_0_ALPHA3 + " or newer.");
             }
         } else if ("16".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_6)) {
-                throw new IllegalArgumentException("Target bytecode 16 requires Groovy " + GROOVY_3_0_6 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_3_0_6 + " or newer.");
             }
         } else if ("15".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_3)) {
-                throw new IllegalArgumentException("Target bytecode 15 requires Groovy " + GROOVY_3_0_3 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_3_0_3 + " or newer.");
             }
         } else if ("14".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_3_0_0_BETA2)) {
-                throw new IllegalArgumentException("Target bytecode 14 requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_3_0_0_BETA2 + " or newer.");
             }
         } else if ("13".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_5_7) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_BETA1))) {
-                throw new IllegalArgumentException("Target bytecode 13 requires Groovy " + GROOVY_2_5_7 + "/" + GROOVY_3_0_0_BETA1 + " or newer. No 2.6 version is supported.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_5_7 + "/" + GROOVY_3_0_0_BETA1 + " or newer. No 2.6 version is supported.");
             }
         } else if ("12".equals(targetBytecode) || "11".equals(targetBytecode) || "10".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_5_3) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_ALPHA4))) {
-                throw new IllegalArgumentException("Target bytecode 10, 11, or 12 requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_3_0_0_ALPHA4 + " or newer. No 2.6 version is supported.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_3_0_0_ALPHA4 + " or newer. No 2.6 version is supported.");
             }
-        } else if ("9".equals(targetBytecode)) {
+        } else if ("9".equals(targetBytecode) || "1.9".equals(targetBytecode)) {
             if (!isGroovyIndy() && (groovyOlderThan(GROOVY_2_5_3)
                     || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_2_6_0_ALPHA4))
                     || (groovyAtLeast(GROOVY_3_0_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_ALPHA2)))) {
-                throw new IllegalArgumentException("Target bytecode 9 requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_2_6_0_ALPHA4 + "/" + GROOVY_3_0_0_ALPHA2 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_2_6_0_ALPHA4 + "/" + GROOVY_3_0_0_ALPHA2 + " or newer.");
             } else if (isGroovyIndy() && (groovyOlderThan(GROOVY_2_5_3) || (groovyAtLeast(GROOVY_2_6_0_ALPHA1) && groovyOlderThan(GROOVY_3_0_0_ALPHA4)))) {
-                throw new IllegalArgumentException("Target bytecode 9 with invokedynamic requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_3_0_0_ALPHA4 + " or newer. No 2.6 version is supported.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_5_3 + "/" + GROOVY_3_0_0_ALPHA4 + " or newer. No 2.6 version is supported.");
             }
-        } else if ("1.8".equals(targetBytecode)) {
+        } else if ("8".equals(targetBytecode) || "1.8".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_3_3)) {
-                throw new IllegalArgumentException("Target bytecode 1.8 requires Groovy " + GROOVY_2_3_3 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_3_3 + " or newer.");
             }
-        } else if ("1.7".equals(targetBytecode) || "1.6".equals(targetBytecode)) {
+        } else if ("7".equals(targetBytecode) || "1.7".equals(targetBytecode) || "6".equals(targetBytecode) || "1.6".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_2_1_3)) {
-                throw new IllegalArgumentException("Target bytecode 1.6 and 1.7 require Groovy " + GROOVY_2_1_3 + " or newer.");
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_2_1_3 + " or newer.");
             }
-        } else if (!"1.5".equals(targetBytecode) && !"1.4".equals(targetBytecode)) {
+        } else if (!"5".equals(targetBytecode) && !"1.5".equals(targetBytecode) && !"4".equals(targetBytecode) && !"1.4".equals(targetBytecode)) {
             throw new IllegalArgumentException("Unrecognized target bytecode: '" + targetBytecode + "'.");
         }
     }


### PR DESCRIPTION
This is to make `targetBytecode` not unexpectedly fail the version validation check since by default the `maven.compiler.target` property defines it. javac allows you to use `5`, `6`, `7`, `8`, and `1.9`, but groovyc does not (although both support `1.5`, `1.6`, `1.7`, `1.8`, and `9`).