### PR TITLE
Change lifecycle phases for adding sources

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddSourcesMojo.java
@@ -28,7 +28,7 @@ import org.apache.maven.shared.model.fileset.FileSet;
  * @author Keegan Witt
  * @since 1.0-beta-1
  */
-@Mojo(name = "addSources", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
+@Mojo(name = "addSources", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
 public class AddSourcesMojo extends AbstractGroovySourcesMojo {
 
     /**

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojo.java
@@ -28,7 +28,7 @@ import org.apache.maven.shared.model.fileset.FileSet;
  * @author Keegan Witt
  * @since 1.0-beta-3
  */
-@Mojo(name = "addTestSources", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
+@Mojo(name = "addTestSources", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, threadSafe = true)
 public class AddTestSourcesMojo extends AbstractGroovySourcesMojo {
 
     /**


### PR DESCRIPTION
It seems that `addSources` and `addTestSources` are run in the `initialize` phase ever since
forever. These goals should be run right before compiling the sources / test sources (in the
`generate-sources` and `generate-test-sources` phases).