### PR TITLE
Support JDK21

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -45,6 +45,11 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod;
 public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
 
     /**
+     * Groovy 4.0.11 version.
+     */
+    protected static final Version GROOVY_4_0_11 = new Version(4, 0, 11);
+
+    /**
      * Groovy 4.0.6 version.
      */
     protected static final Version GROOVY_4_0_6 = new Version(4, 0, 6);
@@ -202,6 +207,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * Using 18 requires Groovy &gt; 4.0.0-beta-1.
      * Using 19 requires Groovy &gt; 4.0.2.
      * Using 20 requires Groovy &gt; 4.0.6.
+     * Using 21 requires Groovy &gt; 4.0.11.
      */
     @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
     protected String targetBytecode;
@@ -490,7 +496,11 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("20".equals(targetBytecode)) {
+        if ("21".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_4_0_11)) {
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_4_0_11 + " or newer.");
+            }
+        } else if ("20".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_4_0_6)) {
                 throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_4_0_6 + " or newer.");
             }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -47,6 +47,11 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod;
 public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSourcesMojo {
 
     /**
+     * Groovy 4.0.11 version.
+     */
+    protected static final Version GROOVY_4_0_11 = new Version(4, 0, 11);
+
+    /**
      * Groovy 4.0.6 version.
      */
     protected static final Version GROOVY_4_0_6 = new Version(4, 0, 6);
@@ -205,6 +210,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * Using 18 requires Groovy &gt; 4.0.0-beta-1.
      * Using 19 requires Groovy &gt; 4.0.2.
      * Using 20 requires Groovy &gt; 4.0.6.
+     * Using 21 requires Groovy &gt; 4.0.11.
      *
      * @since 1.0-beta-3
      */
@@ -417,7 +423,11 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * org.codehaus.groovy.classgen.asm.WriterController.
      */
     protected void verifyGroovyVersionSupportsTargetBytecode() {
-        if ("20".equals(targetBytecode)) {
+        if ("21".equals(targetBytecode)) {
+            if (groovyOlderThan(GROOVY_4_0_11)) {
+                throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_4_0_11 + " or newer.");
+            }
+        } else if ("20".equals(targetBytecode)) {
             if (groovyOlderThan(GROOVY_4_0_6)) {
                 throw new IllegalArgumentException("Target bytecode " + targetBytecode + " requires Groovy " + GROOVY_4_0_6 + " or newer.");
             }

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -405,6 +405,13 @@ public class AbstractCompileMojoTest {
         testMojo.verifyGroovyVersionSupportsTargetBytecode();
     }
 
+    @Test
+    public void testJava21WithSupportedGroovy() {
+        testMojo = new TestMojo("4.0.11");
+        testMojo.targetBytecode = "21";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -432,6 +432,13 @@ public class AbstractGenerateStubsMojoTest {
         testMojo.verifyGroovyVersionSupportsTargetBytecode();
     }
 
+    @Test
+    public void testJava21WithSupportedGroovy() {
+        testMojo = new TestMojo("4.0.11");
+        testMojo.targetBytecode = "21";
+        testMojo.verifyGroovyVersionSupportsTargetBytecode();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testUnrecognizedJava() {
         testMojo = new TestMojo("2.1.2");


### PR DESCRIPTION
JDK 21 constant was introduced in Groovy v4.0.11: https://groovy-lang.org/changelogs/changelog-4.0.11.html