### PR TITLE
Use Java 17 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: full test
         run: >-
           ./mvnw ${MAVEN_ARGS}


### PR DESCRIPTION
This was originally Java 11 because Groovy 2.x doesn't support targetting Java 17 bytecode. However, it does support the default of 1.8 bytecode running on Java 17.