### PR TITLE
Added a warning about Security Manager deprecation and handle exception in Java 17+ (closes #286)

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -86,10 +86,15 @@ public class ConsoleMojo extends AbstractToolsMojo {
         }
 
         if (groovyVersionSupportsAction()) {
-            final SecurityManager sm = System.getSecurityManager();
+            final SecurityManager defaultSecurityManager = System.getSecurityManager();
             try {
                 if (!allowSystemExits) {
-                    System.setSecurityManager(new NoExitSecurityManager());
+                    getLog().warn("JEP 411 deprecated Security Manager in Java 17 for removal. Therefore `allowSystemExits` is also deprecated for removal.");
+                    try {
+                        System.setSecurityManager(new NoExitSecurityManager());
+                    } catch (UnsupportedOperationException e) {
+                        getLog().warn("Attempted to use Security Manager in a JVM where it's disabled by default. You might try `-Djava.security.manager=allow` to override this.");
+                    }
                 }
 
                 // get classes we need with reflection
@@ -129,7 +134,11 @@ public class ConsoleMojo extends AbstractToolsMojo {
                 throw new MojoExecutionException("Error occurred while instantiating a Groovy class from classpath.", e);
             } finally {
                 if (!allowSystemExits) {
-                    System.setSecurityManager(sm);
+                    try {
+                        System.setSecurityManager(defaultSecurityManager);
+                    } catch (UnsupportedOperationException e) {
+                        getLog().warn("Attempted to use Security Manager in a JVM where it's disabled by default. You might try `-Djava.security.manager=allow` to override this.");
+                    }
                 }
             }
         } else {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -91,10 +91,15 @@ public class ShellMojo extends AbstractToolsMojo {
         }
 
         if (groovyVersionSupportsAction()) {
-            final SecurityManager sm = System.getSecurityManager();
+            final SecurityManager defaultSecurityManager = System.getSecurityManager();
             try {
                 if (!allowSystemExits) {
-                    System.setSecurityManager(new NoExitSecurityManager());
+                    getLog().warn("JEP 411 deprecated Security Manager in Java 17 for removal. Therefore `allowSystemExits` is also deprecated for removal.");
+                    try {
+                        System.setSecurityManager(new NoExitSecurityManager());
+                    } catch (UnsupportedOperationException e) {
+                        getLog().warn("Attempted to use Security Manager in a JVM where it's disabled by default. You might try `-Djava.security.manager=allow` to override this.");
+                    }
                 }
 
                 // get classes we need with reflection
@@ -123,7 +128,11 @@ public class ShellMojo extends AbstractToolsMojo {
                 throw new MojoExecutionException("Error occurred while instantiating a Groovy class from classpath.", e);
             } finally {
                 if (!allowSystemExits) {
-                    System.setSecurityManager(sm);
+                    try {
+                        System.setSecurityManager(defaultSecurityManager);
+                    } catch (UnsupportedOperationException e) {
+                        getLog().warn("Attempted to use Security Manager in a JVM where it's disabled by default. You might try `-Djava.security.manager=allow` to override this.");
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
When using a newer Java (such as Java 21), throws an UnsupportedOperationException when attempting to call `System.setSecurityManager` when `java.security.manager` isn't set to `allow`, we make the `allowSystemExit` option a no-op and print a better error message.

In addition, we print a warning about `allowSystemExit` being deprecated.