### PR TITLE
Update the required Maven version to align with the compatibility plan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
       <version>33.2.1-jre</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <!-- fix CVE-2022-29599 from org.apache.maven:maven-core -->
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.3.3</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- main groovy support -->
     <dependency>
       <groupId>${groovyGroupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <groupId>org.codehaus.gmavenplus</groupId>
   <artifactId>gmavenplus-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>3.0.3-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <mavenVersion>3.2.5</mavenVersion>
+    <mavenVersion>3.6.3</mavenVersion>
     <jacocoPluginVersion>0.8.12</jacocoPluginVersion>
     <javadocPluginVersion>3.7.0</javadocPluginVersion>
     <shortJavaVersion>8</shortJavaVersion>
@@ -71,14 +71,7 @@
       <version>3.1.0</version>
     </dependency>
     <dependency>
-      <!-- fix CVE-2022-4244 and CVE-2022-4245 from org.apache.maven:maven-artifact -->
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- fix CVE-2018-10237, CVE-2020-8908, and CVE-2023-2976 from org.apache.maven:maven-core -->
+      <!-- fix CVE-2020-8908 and CVE-2023-2976 from org.apache.maven:maven-core -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.2.1-jre</version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
       <version>3.3.3</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <!-- fix CVE-2024-36124 from org.apache.maven:maven-archiver -->
+      <groupId>org.iq80.snappy</groupId>
+      <artifactId>snappy</artifactId>
+      <version>0.5</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- main groovy support -->
     <dependency>
       <groupId>${groovyGroupId}</groupId>


### PR DESCRIPTION
To align with the [compatibility plan](https://maven.apache.org/developers/compatibility-plan.html), update the required Maven version to 3.6.3.