### PR TITLE
Adding "property" attribute for scripts parameter in execute mojo

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -68,7 +68,7 @@ public class ExecuteMojo extends AbstractToolsMojo {
      * Groovy scripts to run (in order). Can be a script body, a {@link java.net.URL URL} to a script
      * (local or remote), or a filename.
      */
-    @Parameter(required = true, property = "gp.exec.scripts")
+    @Parameter(required = true, property = "scripts")
     protected String[] scripts;
 
     /**

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -90,7 +90,7 @@ public class ExecuteMojo extends AbstractToolsMojo {
      *
      * @since 1.9.1
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "false", property = "skipScriptExecution")
     protected boolean skipScriptExecution;
 
     /**

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -68,7 +68,7 @@ public class ExecuteMojo extends AbstractToolsMojo {
      * Groovy scripts to run (in order). Can be a script body, a {@link java.net.URL URL} to a script
      * (local or remote), or a filename.
      */
-    @Parameter(required = true)
+    @Parameter(required = true, property = "gp.exec.scripts")
     protected String[] scripts;
 
     /**

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -74,7 +74,7 @@ public class ExecuteMojo extends AbstractToolsMojo {
     /**
      * Whether to continue executing remaining scripts when a script fails.
      */
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "false", property = "continueExecuting")
     protected boolean continueExecuting;
 
     /**


### PR DESCRIPTION
Without "property" attribute in "Parameter" calling execute mojo from command line is not working.
For example for call:
`mvn  org.codehaus.gmavenplus:gmavenplus-plugin:4.0.2-SNAPSHOT:execute  -Dscripts="src\main\groovy\FooScript.groovy"`

I got:
`The parameters 'scripts' for goal org.codehaus.gmavenplus:gmavenplus-plugin:4.0.2-SNAPSHOT:execute are missing or invalid`

When "property" attribute is added, execute mojo is working, eg.:

`mvn org.codehaus.gmavenplus:gmavenplus-plugin:4.0.2-SNAPSHOT:execute -Dgp.exec.scripts="src\main\groovy\FooScript.groovy"
`