### PR TITLE
Hack for Maven 4 support

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojo.java
@@ -41,9 +41,21 @@ import static java.util.Collections.singletonList;
  */
 public abstract class AbstractGroovyStubSourcesMojo extends AbstractGroovySourcesMojo {
 
-    static void removeSourceRoot(MavenProject project, String scopeToRemove, File file) throws ClassNotFoundException, NoSuchFieldException, NoSuchMethodException, IllegalAccessException {
+    /**
+     * Removes the source roots from the project, using reflection to avoid breaking changes in Maven 4.
+     *
+     * @param project the Maven project
+     * @param scopeToRemove the scope to remove (main or test)
+     * @param sourceDirectory the source directory to remove
+     * @throws ClassNotFoundException when a class needed cannot be found
+     * @throws NoSuchFieldException when a field needed cannot be found
+     * @throws NoSuchMethodException when a method needed cannot be found
+     * @throws IllegalAccessException when a method needed cannot be accessed
+     */
+    protected static void removeSourceRoot(MavenProject project, String scopeToRemove, File sourceDirectory)
+            throws ClassNotFoundException, NoSuchFieldException, NoSuchMethodException, IllegalAccessException {
         Class<?> sourceRoot = project.getClass().getClassLoader().loadClass("org.apache.maven.api.SourceRoot");
-        Path path = project.getBasedir().toPath().resolve(file.getAbsolutePath()).normalize();
+        Path path = project.getBasedir().toPath().resolve(sourceDirectory.getAbsolutePath()).normalize();
         Field field = project.getClass().getDeclaredField("sources");
         field.setAccessible(true);
         Method scope = sourceRoot.getMethod("scope");

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
@@ -19,8 +19,16 @@ package org.codehaus.gmavenplus.mojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -38,12 +46,42 @@ public class RemoveStubsMojo extends AbstractGroovyStubSourcesMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/groovy-stubs/main")
     protected File stubsOutputDirectory;
 
-    /**
+     /**
      * Executes this mojo.
      */
     @Override
     public void execute() {
-        project.getCompileSourceRoots().remove(stubsOutputDirectory.getAbsolutePath());
+        try {
+            project.getCompileSourceRoots().remove(stubsOutputDirectory.getAbsolutePath());
+        } catch (UnsupportedOperationException e) {
+            String scopeToRemove = "main";
+            try {
+                RemoveStubsMojo.removeSourceRoot(project, scopeToRemove, stubsOutputDirectory);
+            } catch (Throwable e2) {
+                e.addSuppressed(e2);
+                throw e;
+            }
+        }
     }
 
+    static void removeSourceRoot(MavenProject project, String scopeToRemove, File file) throws ClassNotFoundException, NoSuchFieldException, NoSuchMethodException, IllegalAccessException {
+        Class<?> sourceRoot = project.getClass().getClassLoader().loadClass("org.apache.maven.api.SourceRoot");
+        Path path = project.getBasedir().toPath().resolve(file.getAbsolutePath()).normalize();
+        Field field = project.getClass().getDeclaredField("sources");
+        field.setAccessible(true);
+        Method scope = sourceRoot.getMethod("scope");
+        Method language = sourceRoot.getMethod("language");
+        Method directory = sourceRoot.getMethod("directory");
+        Method id = project.getClass().getClassLoader().loadClass("org.apache.maven.api.ExtensibleEnum").getMethod("id");
+        Collection<?> sources = (Collection) field.get(project);
+        sources.removeIf(source -> {
+            try {
+                return Objects.equals(id.invoke(scope.invoke(source)), scopeToRemove)
+                        && Objects.equals(id.invoke(language.invoke(source)), "java")
+                        && Objects.equals(directory.invoke(source), path);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+    }
 }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
@@ -38,7 +38,7 @@ public class RemoveStubsMojo extends AbstractGroovyStubSourcesMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/groovy-stubs/main")
     protected File stubsOutputDirectory;
 
-     /**
+    /**
      * Executes this mojo.
      */
     @Override
@@ -54,4 +54,5 @@ public class RemoveStubsMojo extends AbstractGroovyStubSourcesMojo {
             }
         }
     }
+
 }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
@@ -53,9 +53,8 @@ public class RemoveTestStubsMojo extends AbstractGroovyStubSourcesMojo {
             try {
                 project.getTestCompileSourceRoots().remove(testStubsOutputDirectory.getAbsolutePath());
             } catch (UnsupportedOperationException e) {
-                String scopeToRemove = "test";
                 try {
-                    RemoveStubsMojo.removeSourceRoot(project, scopeToRemove, testStubsOutputDirectory);
+                    removeSourceRoot(project, "test", testStubsOutputDirectory);
                 } catch (Throwable e2) {
                     e.addSuppressed(e2);
                     throw e;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
@@ -50,7 +50,17 @@ public class RemoveTestStubsMojo extends AbstractGroovyStubSourcesMojo {
     @Override
     public void execute() {
         if (!skipTests) {
-            project.getTestCompileSourceRoots().remove(testStubsOutputDirectory.getAbsolutePath());
+            try {
+                project.getTestCompileSourceRoots().remove(testStubsOutputDirectory.getAbsolutePath());
+            } catch (UnsupportedOperationException e) {
+                String scopeToRemove = "test";
+                try {
+                    RemoveStubsMojo.removeSourceRoot(project, scopeToRemove, testStubsOutputDirectory);
+                } catch (Throwable e2) {
+                    e.addSuppressed(e2);
+                    throw e;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Similar to #329 , but try to use reflection to work with Maven 4.0.0-rc-3.
Maven 4.0.0-rc-4 will provide a `removeTestCompileSourceRoot` method on `MavenProject`, but that will still require reflection in order to invoke it.