### PR TITLE
feat: Remove unneeded fork parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,5 +47,5 @@ jobs:
             21
       - name: full test
         run: |
-          ./mvnw org.apache.maven.plugins:maven-toolchains-plugin:generate-jdk-toolchains-xml -Dtoolchain.file=src/it/toolchains.xml
-          ./mvnw ${MAVEN_ARGS} --global-toolchains src/it/toolchains.xml ${MVN_GROOVY_GROUP_ID} ${MVN_GROOVY_VERSION} clean install invoker:install invoker:run
+          ./mvnw org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml -Dtoolchain.file=src/it/toolchains.xml
+          ./mvnw ${MAVEN_ARGS} ${MVN_GROOVY_GROUP_ID} ${MVN_GROOVY_VERSION} clean install invoker:install invoker:run

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.codehaus.gmavenplus</groupId>
   <artifactId>gmavenplus-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>4.3.2-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/forkedCompile/invoker.properties
+++ b/src/it/forkedCompile/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals=clean test
-#invoker.debug = true
+invoker.goals = --global-toolchains ${project.basedir}/src/it/toolchains.xml clean test
+

--- a/src/it/forkedCompile/pom.xml
+++ b/src/it/forkedCompile/pom.xml
@@ -51,7 +51,6 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <configuration>
-          <fork>true</fork>
           <includeClasspath>PROJECT_ONLY</includeClasspath>
         </configuration>
         <executions>

--- a/src/it/forkedCompilePluginClasspath/invoker.properties
+++ b/src/it/forkedCompilePluginClasspath/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals=clean test
-#invoker.debug = true
+invoker.goals = --global-toolchains ${project.basedir}/src/it/toolchains.xml clean test
+

--- a/src/it/forkedCompilePluginClasspath/pom.xml
+++ b/src/it/forkedCompilePluginClasspath/pom.xml
@@ -49,7 +49,6 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <configuration>
-          <fork>true</fork>
           <includeClasspath>PLUGIN_ONLY</includeClasspath>
         </configuration>
         <executions>

--- a/src/it/forkedCompileProjectAndPluginClasspath/invoker.properties
+++ b/src/it/forkedCompileProjectAndPluginClasspath/invoker.properties
@@ -1,2 +1,2 @@
-invoker.goals=clean test
-#invoker.debug = true
+invoker.goals = --global-toolchains ${project.basedir}/src/it/toolchains.xml clean test
+

--- a/src/it/forkedCompileProjectAndPluginClasspath/pom.xml
+++ b/src/it/forkedCompileProjectAndPluginClasspath/pom.xml
@@ -53,7 +53,6 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <configuration>
-          <fork>true</fork>
           <includeClasspath>PROJECT_AND_PLUGIN</includeClasspath>
         </configuration>
         <executions>

--- a/src/it/forkedGroovyDoc/invoker.properties
+++ b/src/it/forkedGroovyDoc/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals=clean test
+invoker.goals = --global-toolchains ${project.basedir}/src/it/toolchains.xml clean test
 #invoker.debug = true
 invoker.postBuildHookScript=verify

--- a/src/it/forkedGroovyDoc/pom.xml
+++ b/src/it/forkedGroovyDoc/pom.xml
@@ -64,9 +64,6 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <configuration>
-          <fork>true</fork>
-        </configuration>
         <executions>
           <execution>
               <phase>generate-sources</phase>

--- a/src/it/forkedStubs/invoker.properties
+++ b/src/it/forkedStubs/invoker.properties
@@ -1,3 +1,3 @@
-invoker.goals=clean test
+invoker.goals = --global-toolchains ${project.basedir}/src/it/toolchains.xml clean test
 #invoker.debug = true
 invoker.postBuildHookScript=verify

--- a/src/it/forkedStubs/pom.xml
+++ b/src/it/forkedStubs/pom.xml
@@ -51,7 +51,6 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <configuration>
-          <fork>true</fork>
           <stubsOutputDirectory>${project.build.directory}/generated-sources/groovy-stubs</stubsOutputDirectory>
         </configuration>
         <executions>

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -184,12 +184,6 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
     protected ToolchainManager toolchainManager;
 
     /**
-     * Whether to fork the compilation when not using a toolchain (toolchains automatically use a forked process).
-     */
-    @Parameter(defaultValue = "false")
-    protected boolean fork;
-
-    /**
      * Performs compilation of compile mojos.
      *
      * @param sources                the sources to compile
@@ -228,10 +222,6 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         if (toolchain != null) {
             getLog().info("Toolchain in gmavenplus-plugin: " + toolchain);
             performForkedCompilation(configuration, toolchain.findTool("java"));
-        } else if (fork) {
-            String javaExecutable = getJavaExecutable();
-            getLog().info("Forking compilation using " + javaExecutable);
-            performForkedCompilation(configuration, javaExecutable);
         } else {
             getLog().info("Performing in-process compilation");
             performInProcessCompilation(configuration, classpath);

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -149,14 +149,6 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected org.apache.maven.execution.MavenSession session;
 
     /**
-     * Whether to fork the compilation when not using a toolchain (toolchains automatically use a forked process).
-     *
-     * @since 4.3.0
-     */
-    @Parameter(property = "fork", defaultValue = "false")
-    protected boolean fork;
-
-    /**
      * Performs the stub generation on the specified source files.
      *
      * @param stubSources     the sources to perform stub generation on
@@ -188,10 +180,6 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
         if (toolchain != null) {
             getLog().info("Toolchain in gmavenplus-plugin: " + toolchain);
             performForkedStubGeneration(configuration, toolchain.findTool("java"));
-        } else if (fork) {
-            String javaExecutable = getJavaExecutable();
-            getLog().info("Forking stub generation using " + javaExecutable);
-            performForkedStubGeneration(configuration, javaExecutable);
         } else {
             getLog().info("Performing in-process stub generation");
             performInProcessStubGeneration(configuration, classpath);

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -240,14 +240,6 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
     protected org.apache.maven.execution.MavenSession session;
 
     /**
-     * Whether to fork the compilation when not using a toolchain (toolchains automatically use a forked process).
-     *
-     * @since 4.3.0
-     */
-    @Parameter(property = "fork", defaultValue = "false")
-    protected boolean fork;
-
-    /**
      * Generates the GroovyDoc for the specified sources.
      *
      * @param sourceDirectories The source directories to generate GroovyDoc for
@@ -300,10 +292,6 @@ public abstract class AbstractGroovyDocMojo extends AbstractGroovySourcesMojo {
         if (toolchain != null) {
             getLog().info("Toolchain in gmavenplus-plugin: " + toolchain);
             performForkedGroovyDocGeneration(configuration, toolchain.findTool("java"));
-        } else if (fork) {
-            String javaExecutable = getJavaExecutable();
-            getLog().info("Forking GroovyDoc generation using " + javaExecutable);
-            performForkedGroovyDocGeneration(configuration, javaExecutable);
         } else {
             getLog().info("Performing in-process GroovyDoc generation");
             performInProcessGroovyDocGeneration(configuration);

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
@@ -238,41 +238,4 @@ public abstract class AbstractGroovyMojo extends AbstractMojo {
         }
     }
 
-    /**
-     * Gets the Java executable to use for forked execution.
-     *
-     * @return the Java executable path
-     */
-    protected String getJavaExecutable() {
-        // Try to get operation system process via JDK 9+ ProcessHandle
-        try {
-            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");
-            // ProcessHandle.current()
-            java.lang.reflect.Method currentMethod = processHandleClass.getMethod("current");
-            Object currentProcess = currentMethod.invoke(null);
-
-            // ProcessHandle.info()
-            java.lang.reflect.Method infoMethod = processHandleClass.getMethod("info");
-            Object info = infoMethod.invoke(currentProcess);
-
-            // ProcessHandle.Info.command()
-            Class<?> infoClass = Class.forName("java.lang.ProcessHandle$Info");
-            java.lang.reflect.Method commandMethod = infoClass.getMethod("command");
-            @SuppressWarnings("unchecked")
-            java.util.Optional<String> commandConfig = (java.util.Optional<String>) commandMethod.invoke(info);
-
-            if (commandConfig.isPresent()) {
-                return commandConfig.get();
-            }
-        } catch (Exception e) {
-            // ignore, we are probably on Java 8 or the OS doesn't support this
-        }
-
-        String javaHome = System.getProperty("java.home");
-        String javaExecutable = javaHome + File.separator + "bin" + File.separator + "java";
-        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-            javaExecutable += ".exe";
-        }
-        return javaExecutable;
-    }
 }


### PR DESCRIPTION
Originally, the `fork` parameter was added to allow users to opt-into using a forked process even if there were no toolchains present. I now think this isn't a use case that likely makes sense and having the parameter likely just causes confusion (indeed, I even messed up the integration tests).