### PR TITLE
chore: Remove copyright in files

### DIFF
--- a/src/it/advancedCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/advancedCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedCompile/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
+++ b/src/it/advancedCompile/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/advancedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/advancedExecute/src/main/resources/groovyScripts/helloWorld.groovy
+++ b/src/it/advancedExecute/src/main/resources/groovyScripts/helloWorld.groovy
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 File targetDir = new File('target')
 if (!targetDir.exists())
     targetDir.mkdir()

--- a/src/it/advancedExecute/src/main/resources/groovyScripts/helloWorld2.groovy
+++ b/src/it/advancedExecute/src/main/resources/groovyScripts/helloWorld2.groovy
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 File targetDir = new File('target')
 if (!targetDir.exists())
     targetDir.mkdir()

--- a/src/it/advancedExecute/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/advancedExecute/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/advancedGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/advancedGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
+++ b/src/it/advancedGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedGenerateStubs/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/advancedGenerateStubs/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/advancedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/advancedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
+++ b/src/it/advancedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeOtherClass.gvy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/advancedGroovydoc/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/advancedGroovydoc/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/astCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/astCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2012 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/astCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/astCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/basicCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/basicCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import groovy.transform.Canonical

--- a/src/it/basicCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/basicCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/basicExecute/src/main/groovy/HelloWorld.groovy
+++ b/src/it/basicExecute/src/main/groovy/HelloWorld.groovy
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 File targetDir = new File('target')
 if (!targetDir.exists())
     targetDir.mkdir()

--- a/src/it/basicExecute/src/test/java/TheTest.java
+++ b/src/it/basicExecute/src/test/java/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/basicGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/basicGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/basicGenerateStubs/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/basicGenerateStubs/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/basicGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/basicGroovydoc/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/basicGroovydoc/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/basicGroovydoc/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/basicGroovydocJar/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/basicGroovydocJar/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/basicGroovydocJar/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/basicGroovydocJar/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/cleanClasspathCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/cleanClasspathCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.apache.maven.project.MavenProject

--- a/src/it/cleanClasspathGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/cleanClasspathGenerateStubs/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.apache.maven.project.MavenProject

--- a/src/it/configScriptCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/configScriptCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/configScriptCompile/src/test/groovy/org/codehaus/gmavenplus/SomeClassTest.groovy
+++ b/src/it/configScriptCompile/src/test/groovy/org/codehaus/gmavenplus/SomeClassTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import groovy.transform.CompileStatic

--- a/src/it/mavenPlugin/mojo/src/main/groovy/org/codehaus/gmavenplus/HelloWorldMojo.groovy
+++ b/src/it/mavenPlugin/mojo/src/main/groovy/org/codehaus/gmavenplus/HelloWorldMojo.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.apache.maven.plugin.AbstractMojo

--- a/src/it/mavenPlugin/mojo/src/test/java/org/codehaus/gmavenplus/HelloWorldMojoTest.java
+++ b/src/it/mavenPlugin/mojo/src/test/java/org/codehaus/gmavenplus/HelloWorldMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Test;

--- a/src/it/mixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
+++ b/src/it/mixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.Child

--- a/src/it/mixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
+++ b/src/it/mixedCompile/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 

--- a/src/it/mixedCompile/src/main/java/org/codehaus/gmavenplus/java/Child.java
+++ b/src/it/mixedCompile/src/main/java/org/codehaus/gmavenplus/java/Child.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 import org.codehaus.gmavenplus.groovy.Parent;

--- a/src/it/mixedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedCompile/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.*;

--- a/src/it/mixedCompile2/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
+++ b/src/it/mixedCompile2/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.Parent

--- a/src/it/mixedCompile2/src/main/java/org/codehaus/gmavenplus/java/Grandchild.java
+++ b/src/it/mixedCompile2/src/main/java/org/codehaus/gmavenplus/java/Grandchild.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.Child;

--- a/src/it/mixedCompile2/src/main/java/org/codehaus/gmavenplus/java/Parent.java
+++ b/src/it/mixedCompile2/src/main/java/org/codehaus/gmavenplus/java/Parent.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 

--- a/src/it/mixedCompile2/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedCompile2/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.*;

--- a/src/it/mixedCompileCircular/src/main/groovy/org/codehaus/gmavenplus/groovy/GClass.g
+++ b/src/it/mixedCompileCircular/src/main/groovy/org/codehaus/gmavenplus/groovy/GClass.g
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.JObject

--- a/src/it/mixedCompileCircular/src/main/groovy/org/codehaus/gmavenplus/groovy/GObject.g
+++ b/src/it/mixedCompileCircular/src/main/groovy/org/codehaus/gmavenplus/groovy/GObject.g
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.JObject

--- a/src/it/mixedCompileCircular/src/main/java/org/codehaus/gmavenplus/java/JClass.java
+++ b/src/it/mixedCompileCircular/src/main/java/org/codehaus/gmavenplus/java/JClass.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 import org.codehaus.gmavenplus.groovy.GObject;

--- a/src/it/mixedCompileCircular/src/main/java/org/codehaus/gmavenplus/java/JObject.java
+++ b/src/it/mixedCompileCircular/src/main/java/org/codehaus/gmavenplus/java/JObject.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 

--- a/src/it/mixedCompileCircular/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedCompileCircular/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.*;

--- a/src/it/mixedCompileMultiModule/groovyModule/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
+++ b/src/it/mixedCompileMultiModule/groovyModule/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 

--- a/src/it/mixedCompileMultiModule/javaModule/src/main/java/org/codehaus/gmavenplus/java/Child.java
+++ b/src/it/mixedCompileMultiModule/javaModule/src/main/java/org/codehaus/gmavenplus/java/Child.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 import org.codehaus.gmavenplus.groovy.Parent;

--- a/src/it/mixedCompileMultiModule/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedCompileMultiModule/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.*;

--- a/src/it/mixedCompileMultiModule2/groovyModule/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
+++ b/src/it/mixedCompileMultiModule2/groovyModule/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.Parent

--- a/src/it/mixedCompileMultiModule2/javaModule/src/main/java/org/codehaus/gmavenplus/java/Parent.java
+++ b/src/it/mixedCompileMultiModule2/javaModule/src/main/java/org/codehaus/gmavenplus/java/Parent.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 

--- a/src/it/mixedCompileMultiModule2/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedCompileMultiModule2/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.*;

--- a/src/it/mixedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
+++ b/src/it/mixedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/groovy/Grandchild.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.Child

--- a/src/it/mixedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
+++ b/src/it/mixedGroovydoc/src/main/groovy/org/codehaus/gmavenplus/groovy/Parent.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 

--- a/src/it/mixedGroovydoc/src/main/java/org/codehaus/gmavenplus/java/Child.java
+++ b/src/it/mixedGroovydoc/src/main/java/org/codehaus/gmavenplus/java/Child.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 import org.codehaus.gmavenplus.groovy.Parent;

--- a/src/it/mixedGroovydoc/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedGroovydoc/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/mixedGroovydoc2/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
+++ b/src/it/mixedGroovydoc2/src/main/groovy/org/codehaus/gmavenplus/groovy/Child.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovy
 
 import org.codehaus.gmavenplus.java.Parent

--- a/src/it/mixedGroovydoc2/src/main/java/org/codehaus/gmavenplus/java/Parent.java
+++ b/src/it/mixedGroovydoc2/src/main/java/org/codehaus/gmavenplus/java/Parent.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.java;
 
 

--- a/src/it/mixedGroovydoc2/src/main/java2/org/codehaus/gmavenplus/java/Grandchild.java
+++ b/src/it/mixedGroovydoc2/src/main/java2/org/codehaus/gmavenplus/java/Grandchild.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.codehaus.gmavenplus.groovy.Child;

--- a/src/it/mixedGroovydoc2/src/test/java/org/codehaus/gmavenplus/TheTest.java
+++ b/src/it/mixedGroovydoc2/src/test/java/org/codehaus/gmavenplus/TheTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/parametersCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/parametersCompile/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/parametersCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/parametersCompile/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import groovy.lang.GroovySystem;

--- a/src/it/pluginAndProjectClasspath/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/pluginAndProjectClasspath/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.apache.maven.project.MavenProject

--- a/src/it/pluginAndProjectClasspath/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/pluginAndProjectClasspath/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/pluginClasspath/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/pluginClasspath/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.apache.maven.project.MavenProject

--- a/src/it/pluginClasspath/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/pluginClasspath/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/shadedGroovy/testModule/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
+++ b/src/it/shadedGroovy/testModule/src/main/groovy/org/codehaus/gmavenplus/SomeClass.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 

--- a/src/it/shadedGroovy/testModule/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
+++ b/src/it/shadedGroovy/testModule/src/test/java/org/codehaus/gmavenplus/SomeClassTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus;
 
 import org.junit.Assert;

--- a/src/it/testDependencyCompile/src/test/groovy/org/codehaus/gmavenplus/SomeTest.groovy
+++ b/src/it/testDependencyCompile/src/test/groovy/org/codehaus/gmavenplus/SomeTest.groovy
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2026 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus
 
 import org.junit.Assert

--- a/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/DotGroovyFile.java
+++ b/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/DotGroovyFile.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovyworkarounds;
 
 import org.codehaus.gmavenplus.util.FileUtils;

--- a/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/GroovyDocTemplateInfo.java
+++ b/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/GroovyDocTemplateInfo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2003-2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovyworkarounds;
 
 import org.codehaus.gmavenplus.model.internal.Version;

--- a/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/package-info.java
+++ b/src/main/java/org/codehaus/gmavenplus/groovyworkarounds/package-info.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Classes to work around issues with Groovy (some of which were fixed in later
  * Groovy versions).

--- a/src/main/java/org/codehaus/gmavenplus/model/GroovyCompileConfiguration.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/GroovyCompileConfiguration.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model;
 
 import java.io.File;

--- a/src/main/java/org/codehaus/gmavenplus/model/GroovyDocConfiguration.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/GroovyDocConfiguration.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model;
 
 import org.apache.maven.shared.model.fileset.FileSet;

--- a/src/main/java/org/codehaus/gmavenplus/model/GroovyStubConfiguration.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/GroovyStubConfiguration.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model;
 
 import java.io.File;

--- a/src/main/java/org/codehaus/gmavenplus/model/Link.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/Link.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2003-2010 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // note that this won't be properly consumed by mojo unless it's in the same package as the mojo
 package org.codehaus.gmavenplus.model;
 

--- a/src/main/java/org/codehaus/gmavenplus/model/Scopes.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/Scopes.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model;
 
 

--- a/src/main/java/org/codehaus/gmavenplus/model/internal/Version.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/internal/Version.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2006-2007 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model.internal;
 
 import java.util.Arrays;

--- a/src/main/java/org/codehaus/gmavenplus/model/internal/package-info.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/internal/package-info.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Classes to model supporting data.
  */

--- a/src/main/java/org/codehaus/gmavenplus/model/package-info.java
+++ b/src/main/java/org/codehaus/gmavenplus/model/package-info.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Classes to model Maven parameters.
  */

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Parameter;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Parameter;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyDocMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Parameter;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.Artifact;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.shared.model.fileset.FileSet;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Component;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddSourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2012 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddStubSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddStubSourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Mojo;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2012 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AddTestStubSourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AddTestStubSourcesMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.Mojo;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/CompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/CompileMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/CompileTestsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/CompileTestsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocJarMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocJarMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsJarMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsJarMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2019 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.archiver.MavenArchiveConfiguration;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2012 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2012 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/codehaus/gmavenplus/mojo/package-info.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/package-info.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Maven mojos.
  */

--- a/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/main/java/org/codehaus/gmavenplus/util/FileUtils.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/FileUtils.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import java.io.*;

--- a/src/main/java/org/codehaus/gmavenplus/util/ForkedGroovyCompiler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ForkedGroovyCompiler.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/main/java/org/codehaus/gmavenplus/util/NoExitSecurityManager.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/NoExitSecurityManager.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import java.security.Permission;

--- a/src/main/java/org/codehaus/gmavenplus/util/ReflectionUtils.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ReflectionUtils.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import java.lang.reflect.Constructor;

--- a/src/main/java/org/codehaus/gmavenplus/util/package-info.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/package-info.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Utility classes.
  */

--- a/src/test/java/org/codehaus/gmavenplus/groovyworkarounds/DotGroovyFileTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/groovyworkarounds/DotGroovyFileTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.groovyworkarounds;
 
 import org.junit.Test;

--- a/src/test/java/org/codehaus/gmavenplus/model/LinkTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/model/LinkTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.model;
 
 import org.junit.Test;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.codehaus.gmavenplus.model.internal.Version;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2011 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.codehaus.gmavenplus.model.internal.Version;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyStubSourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.junit.Before;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.Artifact;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AddSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AddSourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AddStubSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AddStubSourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AddTestSourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AddTestStubSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AddTestStubSourcesMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/CompileTestsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/CompileTestsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/ExecuteMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/ExecuteMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.plugin.MojoExecution;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GenerateTestStubsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/RemoveStubsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/RemoveTestStubsMojoTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.mojo;
 
 import org.apache.maven.project.MavenProject;

--- a/src/test/java/org/codehaus/gmavenplus/util/ClassWranglerTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/util/ClassWranglerTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/test/java/org/codehaus/gmavenplus/util/FileUtilsTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/util/FileUtilsTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2014 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.junit.Test;

--- a/src/test/java/org/codehaus/gmavenplus/util/GroovyCompilerTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/util/GroovyCompilerTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.apache.maven.plugin.logging.Log;

--- a/src/test/java/org/codehaus/gmavenplus/util/ReflectionUtilsTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/util/ReflectionUtilsTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.codehaus.gmavenplus.util;
 
 import org.junit.Test;


### PR DESCRIPTION
It's simpler to just use the LICENSE file instead of duplicating the license in copyright notices all over the project.