### PR TITLE
Fix Javadoc mismatch in ReflectionUtils.getDeclaredMethods

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/util/ReflectionUtils.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ReflectionUtils.java
@@ -220,11 +220,10 @@ public class ReflectionUtils {
     }
 
     /**
-     * This variant retrieves {@link Class#getDeclaredMethods()} from a local cache in order to avoid the JVM's SecurityManager check and defensive array copying.
-     * In addition, it also includes Java 8 default methods from locally implemented interfaces, since those are effectively to be treated just like declared methods.
+     * This variant retrieves {@link Class#getDeclaredMethods()} and also includes Java 8 default methods from locally implemented interfaces, since those are effectively to be treated just like declared methods.
      *
      * @param clazz the class to introspect
-     * @return the cached array of methods
+     * @return the array of methods
      * @see Class#getDeclaredMethods()
      */
     private static Method[] getDeclaredMethods(Class<?> clazz) {


### PR DESCRIPTION
The Javadoc for getDeclaredMethods claimed to use a local cache and avoid SecurityManager checks and defensive array copying, but the implementation did not actually provide a cache.

Updated the Javadoc to accurately reflect the current implementation, while retaining the information about Java 8 default methods.