### PR TITLE
⚡ Optimize collection to array conversion

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovySourcesMojo.java
@@ -95,7 +95,7 @@ public abstract class AbstractGroovySourcesMojo extends AbstractGroovyMojo {
                 javaFileSet.setIncludes(singletonList(JAVA_SOURCES_PATTERN));
                 javaFileSets.add(javaFileSet);
             }
-            FileSet[] javaFileSetsArr = javaFileSets.toArray(new FileSet[0]);
+            FileSet[] javaFileSetsArr = javaFileSets.toArray(new FileSet[javaFileSets.size()]);
             result = Arrays.copyOf(groovyFileSets, groovyFileSets.length + javaFileSetsArr.length);
             System.arraycopy(javaFileSetsArr, 0, result, groovyFileSets.length, javaFileSetsArr.length);
         } else {
@@ -134,7 +134,7 @@ public abstract class AbstractGroovySourcesMojo extends AbstractGroovyMojo {
                 javaFileSet.setIncludes(singletonList(JAVA_SOURCES_PATTERN));
                 javaFileSets.add(javaFileSet);
             }
-            FileSet[] javaFileSetsArr = javaFileSets.toArray(new FileSet[0]);
+            FileSet[] javaFileSetsArr = javaFileSets.toArray(new FileSet[javaFileSets.size()]);
             result = Arrays.copyOf(groovyFileSets, groovyFileSets.length + javaFileSetsArr.length);
             System.arraycopy(javaFileSetsArr, 0, result, groovyFileSets.length, javaFileSetsArr.length);
         } else {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -224,7 +224,7 @@ public class ConsoleMojo extends AbstractToolsMojo {
      */
     protected void waitForConsoleClose() throws MojoFailureException {
         Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-        Thread[] threadArray = threadSet.toArray(new Thread[0]);
+        Thread[] threadArray = threadSet.toArray(new Thread[threadSet.size()]);
         Thread consoleThread = null;
         for (Thread thread : threadArray) {
             if ("AWT-Shutdown".equals(thread.getName())) {

--- a/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
@@ -234,12 +234,12 @@ public class ClassWrangler {
      * @throws MalformedURLException when a classpath element provides a malformed URL
      */
     protected ClassLoader createNewClassLoader(final List<?> classpath, final ClassLoader classLoader) throws MalformedURLException {
-        List<URL> urlsList = new ArrayList<>();
+        List<URL> urlsList = new ArrayList<>(classpath.size());
         for (Object classPathObject : classpath) {
             String path = (String) classPathObject;
             urlsList.add(new File(path).toURI().toURL());
         }
-        URL[] urlsArray = urlsList.toArray(new URL[0]);
+        URL[] urlsArray = urlsList.toArray(new URL[urlsList.size()]);
         return new URLClassLoader(urlsArray, classLoader);
     }
 

--- a/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
@@ -381,7 +381,7 @@ public class GroovyCompiler {
         if ((ClassWrangler.groovyAtLeast(classWrangler.getGroovyVersion(), GROOVY_4_0_27) && ClassWrangler.groovyOlderThan(classWrangler.getGroovyVersion(), GROOVY_5_0_0_ALPHA1)) || ClassWrangler.groovyAtLeast(classWrangler.getGroovyVersion(), GROOVY_5_0_0_BETA_1)) {
              groovyDocTool = invokeConstructor(findConstructor(groovyDocToolClass, resourceManagerClass, String[].class, String[].class, String[].class, String[].class, List.class, String.class, Properties.class),
                     classpathResourceManager,
-                    sourceDirectories.toArray(new String[0]),
+                    sourceDirectories.toArray(new String[sourceDirectories.size()]),
                     defaultDocTemplates == null ? groovyDocTemplateInfo.defaultDocTemplates() : defaultDocTemplates,
                     defaultPackageTemplates == null ? groovyDocTemplateInfo.defaultPackageTemplates() : defaultPackageTemplates,
                     defaultClassTemplates == null ? groovyDocTemplateInfo.defaultClassTemplates() : defaultClassTemplates,
@@ -392,7 +392,7 @@ public class GroovyCompiler {
         } else if (ClassWrangler.groovyAtLeast(classWrangler.getGroovyVersion(), GROOVY_1_6_0_RC2)) {
             groovyDocTool = invokeConstructor(findConstructor(groovyDocToolClass, resourceManagerClass, String[].class, String[].class, String[].class, String[].class, List.class, Properties.class),
                     classpathResourceManager,
-                    sourceDirectories.toArray(new String[0]),
+                    sourceDirectories.toArray(new String[sourceDirectories.size()]),
                     defaultDocTemplates == null ? groovyDocTemplateInfo.defaultDocTemplates() : defaultDocTemplates,
                     defaultPackageTemplates == null ? groovyDocTemplateInfo.defaultPackageTemplates() : defaultPackageTemplates,
                     defaultClassTemplates == null ? groovyDocTemplateInfo.defaultClassTemplates() : defaultClassTemplates,


### PR DESCRIPTION
- Update `ClassWrangler.java` to use correctly sized array in `toArray()` and pre-size `ArrayList`.
- Update `ConsoleMojo.java`, `AbstractGroovySourcesMojo.java`, and `GroovyCompiler.java` to use correctly sized array in `toArray()`.

This avoids unnecessary zero-length array allocation and internal reflection-based resizing, improving performance in the Java 8 environment.