### PR TITLE
🧹 Use diamond operator for ArrayList initialization in GroovyCompiler

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
@@ -341,9 +341,8 @@ public class GroovyCompiler {
         performGroovyDocGeneration(configuration.getOutputDirectory(), groovyDocToolClass, outputToolClass, fileOutputTool, groovyDocSources, groovyDocTool);
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     protected List<?> setupLinks(GroovyDocConfiguration configuration) throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, InstantiationException {
-        List linksList = new ArrayList();
+        List<Object> linksList = new ArrayList<>();
         if (configuration.getLinks() != null && !configuration.getLinks().isEmpty()) {
             Class<?> linkArgumentClass = null;
             if (configuration.getLinkArgumentClass() == null) {


### PR DESCRIPTION
This change replaces a raw ArrayList initialization with the diamond operator in the setupLinks method of GroovyCompiler.java. This improves maintainability and follows modern Java practices. The @SuppressWarnings annotation has been removed as it is no longer necessary.