### PR TITLE
Refactor Groovy version detection to use custom exception

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/ClassWrangler.java
@@ -124,7 +124,7 @@ public class ClassWrangler {
         try {
             return Version.parseFromString(getGroovyVersionString());
         } catch (Exception e) {
-            throw new RuntimeException("Unable to determine Groovy version. Is Groovy declared as a dependency?");
+            throw new GroovyVersionException("Unable to determine Groovy version. Is Groovy declared as a dependency?", e);
         }
     }
 
@@ -259,7 +259,7 @@ public class ClassWrangler {
 
             return groovyJar;
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Unable to determine Groovy version. Is Groovy declared as a dependency?");
+            throw new GroovyVersionException("Unable to determine Groovy version. Is Groovy declared as a dependency?", e);
         }
     }
 

--- a/src/main/java/org/codehaus/gmavenplus/util/GroovyVersionException.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/GroovyVersionException.java
@@ -1,0 +1,30 @@
+package org.codehaus.gmavenplus.util;
+
+/**
+ * Exception thrown when Groovy version cannot be determined.
+ *
+ * @author Keegan Witt
+ * @since 4.3.2
+ */
+public class GroovyVersionException extends RuntimeException {
+
+    /**
+     * Constructs a new GroovyVersionException with the specified message.
+     *
+     * @param message the detail message
+     */
+    public GroovyVersionException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new GroovyVersionException with the specified message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public GroovyVersionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}


### PR DESCRIPTION
Replaced raw RuntimeException with GroovyVersionException in ClassWrangler. This improves maintainability and error handling by providing a more specific exception type and preserving the original cause.

Key changes:
- Created GroovyVersionException (unchecked) in util package.
- Updated ClassWrangler.getGroovyVersion() to throw GroovyVersionException.
- Updated ClassWrangler.getGroovyJar() to throw GroovyVersionException.
- Included the original cause in the new exception for better debuggability.