### PR TITLE
perf: cache javac target to bytecode mapping

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
+++ b/src/main/java/org/codehaus/gmavenplus/util/GroovyCompiler.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.CodeSource;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -249,6 +250,21 @@ public class GroovyCompiler {
      * Java 1.8 version.
      */
     protected static final Version JAVA_12 = new Version(12);
+
+    /**
+     * The mapping of javac target to Groovy target bytecode.
+     */
+    private static final Map<String, String> JAVAC_TARGET_TO_TARGET_BYTECODE;
+
+    static {
+        Map<String, String> javacTargetToTargetBytecode = new HashMap<>();
+        javacTargetToTargetBytecode.put("5", "1.5");
+        javacTargetToTargetBytecode.put("6", "1.6");
+        javacTargetToTargetBytecode.put("7", "1.7");
+        javacTargetToTargetBytecode.put("8", "1.8");
+        javacTargetToTargetBytecode.put("1.9", "9");
+        JAVAC_TARGET_TO_TARGET_BYTECODE = Collections.unmodifiableMap(javacTargetToTargetBytecode);
+    }
 
     private final ClassWrangler classWrangler;
     private final Log log;
@@ -758,13 +774,7 @@ public class GroovyCompiler {
     }
 
     public static String translateJavacTargetToTargetBytecode(String targetBytecode) {
-        Map<String, String> javacTargetToTargetBytecode = new HashMap<>();
-        javacTargetToTargetBytecode.put("5", "1.5");
-        javacTargetToTargetBytecode.put("6", "1.6");
-        javacTargetToTargetBytecode.put("7", "1.7");
-        javacTargetToTargetBytecode.put("8", "1.8");
-        javacTargetToTargetBytecode.put("1.9", "9");
-        return javacTargetToTargetBytecode.getOrDefault(targetBytecode, targetBytecode);
+        return JAVAC_TARGET_TO_TARGET_BYTECODE.getOrDefault(targetBytecode, targetBytecode);
     }
 
     protected boolean isJavaSupportIndy() {


### PR DESCRIPTION
Extracts the static mapping in translateJavacTargetToTargetBytecode to a private static final field initialized once in a static block. This avoids repeated object allocation and map population on every method call.