### PR TITLE
fix: Fix Groovy 5 shell support (closes #367)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,19 +104,62 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>2.4.2</version>
+      <version>1.14</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <!-- this is to support use of Groovysh (Groovy jars don't include) -->
-      <!-- this will work for all Groovy >= 2.2.0-beta-1 -->
+      <!-- this will work for all Groovy >= 2.2.0-beta-1 and < 5.0.0-rc-1 -->
       <!-- users of older versions will need to pull in 1.0 as a runtime dependency -->
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
       <version>2.14.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-builtins</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-console</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jna</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.16.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-reader</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jni</artifactId>
+      <version>3.30.6</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
       <artifactId>commons-io</artifactId>
       <version>2.21.0</version>
     </dependency>
-    <!-- main groovy support -->
     <dependency>
       <groupId>${groovyGroupId}</groupId>
       <artifactId>groovy</artifactId>
@@ -102,79 +101,6 @@
       <artifactId>groovy-groovydoc</artifactId>
       <version>${groovyVersion}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi</artifactId>
-      <version>1.14</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
-      <!-- this will work for all Groovy >= 2.2.0-beta-1 and < 5.0.0-rc-1 -->
-      <!-- users of older versions will need to pull in 1.0 as a runtime dependency -->
-      <groupId>jline</groupId>
-      <artifactId>jline</artifactId>
-      <version>2.14.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-terminal</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-builtins</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-console</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-terminal-jna</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>5.16.0</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-reader</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
-      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
-      <groupId>org.jline</groupId>
-      <artifactId>jline-terminal-jni</artifactId>
-      <version>3.30.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- this is to support use of AntBuilder (Groovy jars don't include) -->
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant</artifactId>
-      <version>1.10.15</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- this is to support use of @grab (Groovy jars don't include) -->
-      <groupId>org.apache.ivy</groupId>
-      <artifactId>ivy</artifactId>
-      <version>2.5.3</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,51 @@
     </dependency>
     <dependency>
       <!-- this is to support use of Groovysh (Groovy jars don't include) -->
-      <!-- this will work for all Groovy >= 2.2.0-beta-1 -->
+      <!-- this will work for all Groovy >= 2.2.0-beta-1 and < 5.0.0-rc-1 -->
       <!-- users of older versions will need to pull in 1.0 as a runtime dependency -->
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
       <version>2.14.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-console</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-reader</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jansi</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jna</artifactId>
+      <version>3.30.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- this is to support use of Groovysh (Groovy jars don't include) -->
+      <!-- this will work for all Groovy >= 5.0.0-rc-1 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jni</artifactId>
+      <version>3.30.6</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/src/it/advancedExecute/pom.xml
+++ b/src/it/advancedExecute/pom.xml
@@ -103,6 +103,16 @@
             <artifactId>groovy-ant</artifactId>
             <version>@groovyVersion@</version>
           </dependency>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>${antVersion}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <version>${ivyVersion}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/src/it/basicExecute/pom.xml
+++ b/src/it/basicExecute/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>groovy</artifactId>
             <version>@groovyVersion@</version>
           </dependency>
-          <dependency>
-            <groupId>@groovyGroupId@</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <version>@groovyVersion@</version>
-          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/src/it/forkedGroovyDoc/pom.xml
+++ b/src/it/forkedGroovyDoc/pom.xml
@@ -32,12 +32,6 @@
             <version>4.0.29</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <version>4.0.29</version>
-            <scope>compile</scope>
-        </dependency>
   </dependencies>
 
   <build>

--- a/src/it/mixedCompile/pom.xml
+++ b/src/it/mixedCompile/pom.xml
@@ -26,10 +26,6 @@
       <groupId>@groovyGroupId@</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
-    <dependency>
-      <groupId>@groovyGroupId@</groupId>
-      <artifactId>groovy-ant</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/mixedCompile2/pom.xml
+++ b/src/it/mixedCompile2/pom.xml
@@ -26,10 +26,6 @@
       <groupId>@groovyGroupId@</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
-    <dependency>
-      <groupId>@groovyGroupId@</groupId>
-      <artifactId>groovy-ant</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/mixedCompileMultiModule/groovyModule/pom.xml
+++ b/src/it/mixedCompileMultiModule/groovyModule/pom.xml
@@ -24,10 +24,6 @@
       <groupId>@groovyGroupId@</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
-    <dependency>
-      <groupId>@groovyGroupId@</groupId>
-      <artifactId>groovy-ant</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/mixedCompileMultiModule2/groovyModule/pom.xml
+++ b/src/it/mixedCompileMultiModule2/groovyModule/pom.xml
@@ -28,10 +28,6 @@
       <groupId>@groovyGroupId@</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
-    <dependency>
-      <groupId>@groovyGroupId@</groupId>
-      <artifactId>groovy-ant</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/multimodulePluginAndProjectClasspath/pom.xml
+++ b/src/it/multimodulePluginAndProjectClasspath/pom.xml
@@ -21,10 +21,6 @@
       <groupId>@groovyGroupId@</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
-    <dependency>
-      <groupId>@groovyGroupId@</groupId>
-      <artifactId>groovy-ant</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/multimodulePluginAndProjectClasspath2/pom.xml
+++ b/src/it/multimodulePluginAndProjectClasspath2/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>groovy</artifactId>
             <version>@groovyVersion@</version>
           </dependency>
-          <dependency>
-            <groupId>@groovyGroupId@</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <version>@groovyVersion@</version>
-          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/src/it/multimodulePluginClasspath/pom.xml
+++ b/src/it/multimodulePluginClasspath/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>groovy</artifactId>
             <version>@groovyVersion@</version>
           </dependency>
-          <dependency>
-            <groupId>@groovyGroupId@</groupId>
-            <artifactId>groovy-ant</artifactId>
-            <version>@groovyVersion@</version>
-          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -13,6 +13,8 @@
     <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
     <commonsLang3Version>3.20.0</commonsLang3Version>
     <junit6Version>6.0.2</junit6Version>
+    <antVersion>1.10.15</antVersion>
+    <ivyVersion>2.5.3</ivyVersion>
   </properties>
 
   <dependencyManagement>
@@ -61,6 +63,16 @@
         <groupId>@groovyGroupId@</groupId>
         <artifactId>groovy-templates</artifactId>
         <version>@groovyVersion@</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>${antVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ivy</groupId>
+        <artifactId>ivy</artifactId>
+        <version>${ivyVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractToolsMojo.java
@@ -16,6 +16,7 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeConstructor;
  * The base tools mojo, which all tool mojos extend.
  * Note that it references the plugin classloader to pull in dependencies
  * Groovy didn't include (for things like Ant for AntBuilder, Ivy for @grab, and Jansi for Groovysh).
+ * These dependencies are now optional and must be provided by the user if needed.
  * Note that using the <code>ant</code> property requires Java 8, as the included Ant version was compiled for Java 8.
  *
  * @author Keegan Witt
@@ -137,22 +138,20 @@ public abstract class AbstractToolsMojo extends AbstractGroovyMojo {
             properties.put("projectHelper", projectHelper);
         }
         if (!properties.containsKey("ant")) {
-            Object antBuilder = null;
-            try {
-                antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.ant.AntBuilder")));
-            } catch (ClassNotFoundException e1) {
-                getLog().debug("groovy.ant.AntBuilder not available, trying groovy.util.AntBuilder.");
-                try {
-                    antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.util.AntBuilder")));
-                } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | InvocationTargetException e2) {
-                    logUnableToInitializeAntBuilder(e2);
-                }
-            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-                logUnableToInitializeAntBuilder(e);
-            }
+            Object antBuilder = createAntBuilder();
             if (antBuilder != null) {
                 properties.put("ant", antBuilder);
             }
+        }
+        try {
+            classWrangler.getClass("org.apache.tools.ant.Project");
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            logMissingAntDependency();
+        }
+        try {
+            classWrangler.getClass("org.apache.ivy.Ivy");
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            logMissingIvyDependency();
         }
         if (bindSessionUserOverrideProperties && !bindAllProjectProperties) {
             getLog().warn("bindSessionUserOverrideProperties set without bindAllProjectProperties, ignoring.");
@@ -177,12 +176,55 @@ public abstract class AbstractToolsMojo extends AbstractGroovyMojo {
     }
 
     /**
+     * Attempts to create a new AntBuilder object.
+     *
+     * @return a new AntBuilder object, or <code>null</code> if it couldn't be created
+     */
+    protected Object createAntBuilder() {
+        Object antBuilder = null;
+        try {
+            antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.ant.AntBuilder")));
+        } catch (ClassNotFoundException e1) {
+            getLog().debug("groovy.ant.AntBuilder not available, trying groovy.util.AntBuilder.");
+            try {
+                antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.util.AntBuilder")));
+            } catch (ClassNotFoundException e2) {
+                logUnableToInitializeAntBuilder(e2);
+            } catch (NoClassDefFoundError e2) {
+                logMissingAntDependency();
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e2) {
+                logUnableToInitializeAntBuilder(e2);
+            }
+        } catch (NoClassDefFoundError e) {
+            logMissingAntDependency();
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            logUnableToInitializeAntBuilder(e);
+        }
+
+        return antBuilder;
+    }
+
+    /**
      * Logs errors that caused the 'ant' object to not be populated.
      *
      * @param e the exception causing the failure
      */
     protected void logUnableToInitializeAntBuilder(final Throwable e) {
-        getLog().warn("Unable to initialize 'ant' with a new AntBuilder object. Is Groovy a dependency?  If you are using Groovy >= 2.3.0-rc-1, remember to include groovy-ant as a dependency.");
+        getLog().warn("Unable to initialize 'ant' with a new AntBuilder object. Is Groovy a dependency? If you are using Groovy >= 2.3.0-rc-1, remember to include groovy-ant as a dependency.");
+    }
+
+    /**
+     * Logs a warning that the Ant dependency is missing.
+     */
+    protected void logMissingAntDependency() {
+        getLog().warn("Ant dependency was not found on the project or plugin classpath. If you use AntBuilder, you should add it as a runtime dependency.");
+    }
+
+    /**
+     * Logs a warning that the Ivy dependency is missing.
+     */
+    protected void logMissingIvyDependency() {
+        getLog().warn("Ivy dependency was not found on the project or plugin classpath. If you use @Grab, you should add it as a runtime dependency.");
     }
 
 }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -27,7 +27,8 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod;
  * Launches a Groovy console window bound to the current project.
  * Note that this mojo requires Groovy &gt;= 1.5.0.
  * Note that it references the plugin classloader to pull in dependencies Groovy didn't include
- * (for things like Ant for AntBuilder, Ivy for @grab, and Jansi for Groovysh).
+ * (for things like Ant for AntBuilder and Ivy for @grab).
+ * These dependencies are now optional and must be provided by the user if needed.
  * Note that using the <code>ant</code> property requires Java 8, as the included Ant version was compiled for Java 8.
  *
  * @author Keegan Witt
@@ -114,7 +115,7 @@ public class ConsoleMojo extends AbstractToolsMojo {
             // wait for console to be closed
             waitForConsoleClose();
         } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project or the plugin?", e);
+            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Ensure groovy-console is on your project or plugin classpath.", e);
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof NoClassDefFoundError && "org/apache/ivy/core/report/ResolveReport".equals(e.getCause().getMessage())) {
                 throw new MojoExecutionException("Groovy 1.7.6 and 1.7.7 have a dependency on Ivy to run the console. Either change your Groovy version or add Ivy as a project or plugin dependency.", e);
@@ -199,19 +200,7 @@ public class ConsoleMojo extends AbstractToolsMojo {
             Class<?> groovyShellClass = classWrangler.getClass("groovy.lang.GroovyShell");
             Object shell = getField(findField(consoleClass, "shell", groovyShellClass), console);
             Object binding = invokeMethod(findMethod(groovyShellClass, "getContext"), shell);
-            Object antBuilder = null;
-            try {
-                antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.ant.AntBuilder")));
-            } catch (ClassNotFoundException e1) {
-                getLog().debug("groovy.ant.AntBuilder not available, trying groovy.util.AntBuilder.");
-                try {
-                    antBuilder = invokeConstructor(findConstructor(classWrangler.getClass("groovy.util.AntBuilder")));
-                } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException | InstantiationException e2) {
-                    logUnableToInitializeAntBuilder(e2);
-                }
-            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-                logUnableToInitializeAntBuilder(e);
-            }
+            Object antBuilder = createAntBuilder();
             if (antBuilder != null) {
                 if (bindPropertiesToSeparateVariables) {
                     invokeMethod(findMethod(bindingClass, "setVariable", String.class, Object.class), binding, "ant", antBuilder);

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ConsoleMojo.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.codehaus.gmavenplus.model.internal.Version;
 import org.codehaus.gmavenplus.util.NoExitSecurityManager;
 
 import java.io.File;
@@ -14,7 +15,6 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.util.Set;
 
-import static org.codehaus.gmavenplus.mojo.ExecuteMojo.GROOVY_4_0_0_RC_1;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findConstructor;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findField;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findMethod;
@@ -35,6 +35,11 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod;
  */
 @Mojo(name = "console", requiresDependencyResolution = ResolutionScope.TEST)
 public class ConsoleMojo extends AbstractToolsMojo {
+
+    /**
+     * Groovy 4.0.0-RC-1 version.
+     */
+    protected static final Version GROOVY_4_0_0_RC1 = new Version(4, 0, 0, "RC-1");
 
     /**
      * Script file to load into console. Can also be a project property referring to a file.
@@ -169,10 +174,10 @@ public class ConsoleMojo extends AbstractToolsMojo {
                 invokeMethod(setVariable, binding, k, properties.get(k));
             }
         } else {
-            if (groovyOlderThan(GROOVY_4_0_0_RC_1)) {
+            if (groovyOlderThan(GROOVY_4_0_0_RC1)) {
                 invokeMethod(setVariable, binding, "properties", properties);
             } else {
-                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC_1 + " and later.");
+                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
             }
         }
 

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -31,7 +31,8 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeMethod;
  * Executes Groovy scripts (in the pom or external), bound to the current project.
  * Note that this mojo requires Groovy &gt;= 1.5.0.
  * Note that it references the plugin classloader to pull in dependencies Groovy didn't include
- * (for things like Ant for AntBuilder, Ivy for @grab, and Jansi for Groovysh).
+ * (for things like Ant for AntBuilder and Ivy for @grab).
+ * These dependencies are now optional and must be provided by the user if needed.
  *
  * @author Keegan Witt
  * @since 1.0-beta-1

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ExecuteMojo.java
@@ -42,7 +42,7 @@ public class ExecuteMojo extends AbstractToolsMojo {
     /**
      * Groovy 4.0.0-RC-1 version.
      */
-    protected static final Version GROOVY_4_0_0_RC_1 = new Version(4, 0, 0, "RC-1");
+    protected static final Version GROOVY_4_0_0_RC1 = new Version(4, 0, 0, "RC-1");
 
     /**
      * Groovy 1.7.0 version.
@@ -207,10 +207,10 @@ public class ExecuteMojo extends AbstractToolsMojo {
                 invokeMethod(setProperty, shell, k, properties.get(k));
             }
         } else {
-            if (groovyOlderThan(GROOVY_4_0_0_RC_1)) {
+            if (groovyOlderThan(GROOVY_4_0_0_RC1)) {
                 invokeMethod(setProperty, shell, "properties", properties);
             } else {
-                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC_1 + " and later.");
+                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
             }
         }
 

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocMojo.java
@@ -57,7 +57,7 @@ public class GroovyDocMojo extends AbstractGroovyDocMojo {
             }
             doGroovyDocGeneration(getFilesets(sources, groovyDocJavaSources), project.getRuntimeClasspathElements(), groovyDocOutputDirectory);
         } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project?", e);
+            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Ensure groovy-groovydoc is on your project or plugin classpath.", e);
         } catch (InvocationTargetException e) {
             throw new MojoExecutionException("Error occurred while calling a method on a Groovy class from classpath.", e);
         } catch (InstantiationException e) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/GroovyDocTestsMojo.java
@@ -57,7 +57,7 @@ public class GroovyDocTestsMojo extends AbstractGroovyDocMojo {
             }
             doGroovyDocGeneration(getTestFilesets(testSources, testGroovyDocJavaSources), project.getTestClasspathElements(), testGroovyDocOutputDirectory);
         } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project?", e);
+            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Ensure groovy-groovydoc is on your project or plugin classpath.", e);
         } catch (InvocationTargetException e) {
             throw new MojoExecutionException("Error occurred while calling a method on a Groovy class from classpath.", e);
         } catch (InstantiationException e) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -11,8 +11,9 @@ import org.codehaus.gmavenplus.util.NoExitSecurityManager;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.codehaus.gmavenplus.mojo.ExecuteMojo.GROOVY_4_0_0_RC_1;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findConstructor;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findField;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findMethod;
@@ -34,9 +35,34 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeStaticMethod;
 public class ShellMojo extends AbstractToolsMojo {
 
     /**
+     * Groovy 2.2.0 beta-1 version.
+     */
+    protected static final Version GROOVY_2_2_0_BETA1 = new Version(2, 2, 0, "beta-1");
+
+    /**
      * Groovy 4.0.0 alpha-1 version.
      */
     protected static final Version GROOVY_4_0_0_ALPHA1 = new Version(4, 0, 0, "alpha-1");
+
+     /**
+      * Groovy 4.0.0 RC-1 version.
+      */
+     protected static final Version GROOVY_4_0_0_RC1 = new Version(4, 0, 0, "RC-1");
+
+    /**
+     * Groovy 5.0.0-alpha-1 version.
+     */
+    protected static final Version GROOVY_5_0_0_ALPHA1 = new Version(5, 0, 0, "alpha-1");
+
+    /**
+     * Groovy 5.0.0-beta-2 version.
+     */
+    protected static final Version GROOVY_5_0_0_BETA2 = new Version(5, 0, 0, "beta-2");
+
+    /**
+      * Groovy 5.0.4 version.
+      */
+     protected static final Version GROOVY_5_0_4 = new Version(5, 0, 4);
 
     /**
      * Groovy shell verbosity level. Should be one of:
@@ -90,23 +116,56 @@ public class ShellMojo extends AbstractToolsMojo {
                 }
             }
 
-            // get classes we need with reflection
-            Class<?> shellClass = classWrangler.getClass(groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh.Groovysh" : "org.codehaus.groovy.tools.shell.Groovysh");
-            Class<?> bindingClass = classWrangler.getClass("groovy.lang.Binding");
-            Class<?> ioClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO");
-            Class<?> verbosityClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO$Verbosity");
-            Class<?> loggerClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.util.Logger");
+            if (groovyAtLeast(GROOVY_5_0_4)) {
+                executeGroovy5Shell();
+            } else {
+                if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
+                    try {
+                        classWrangler.getClass("org.jline.reader.LineReader");
+                    } catch (ClassNotFoundException e) {
+                        throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
+                    }
+                }
+                // get classes we need with reflection
+                Class<?> shellClass = classWrangler.getClass(groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh.Groovysh" : "org.codehaus.groovy.tools.shell.Groovysh");
+                Class<?> bindingClass = classWrangler.getClass("groovy.lang.Binding");
+                Class<?> ioClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO");
+                Class<?> verbosityClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO$Verbosity");
+                Class<?> loggerClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.util.Logger");
 
-            // create shell to run
-            Object shell = setupShell(shellClass, bindingClass, ioClass, verbosityClass, loggerClass);
+                // create shell to run
+                Object shell = setupShell(shellClass, bindingClass, ioClass, verbosityClass, loggerClass);
 
-            // run the shell
-            invokeMethod(findMethod(shellClass, "run", String.class), shell, (String) null);
+                // run the shell
+                if (groovyOlderThan(GROOVY_5_0_4)) {
+                    try {
+                        Class<?> ansiConsoleClass = classWrangler.getClass("org.fusesource.jansi.AnsiConsole");
+                        ansiConsoleClass.getMethod("wrapOutputStream", java.io.OutputStream.class);
+                    } catch (Exception e) {
+                        String message = "Jansi 2.x detected, which is incompatible with JLine 2. Falling back to dumb terminal. Colors will be disabled.";
+                        if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
+                            message += " We recommend upgrading to Groovy 5.0.4 or newer for full JLine 3 support.";
+                        }
+                        getLog().warn(message);
+                        System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
+                    }
+                }
+                invokeMethod(findMethod(shellClass, "run", String.class), shell, (String) null);
+            }
         } catch (ClassNotFoundException e) {
+            if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
+                throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). This Groovy version (" + classWrangler.getGroovyVersionString() + ") revamped the shell to use JLine 3 and removed some older classes. You might need to use Groovy 5.0.4 or later for full support.", e);
+            }
             throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project or the plugin?", e);
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof NoClassDefFoundError && e.getCause().getMessage() != null && e.getCause().getMessage().contains("jline")) {
-                throw new MojoExecutionException("Unable to get a JLine class from classpath. This might be because of a JLine version mismatch. If you are using Groovy < 2.2.0-beta-1, make sure you include JLine 1.0 as a runtime dependency in your project or the plugin.", e);
+                if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
+                    throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
+                } else if (groovyAtLeast(GROOVY_2_2_0_BETA1)) {
+                    throw new MojoExecutionException("Unable to get a JLine 2 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 2.x as a runtime dependency in your project or the plugin.", e);
+                } else {
+                    throw new MojoExecutionException("Unable to get a JLine 1 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 1.x as a runtime dependency in your project or the plugin.", e);
+                }
             } else {
                 throw new MojoExecutionException("Error occurred while calling a method on a Groovy class from classpath.", e);
             }
@@ -147,10 +206,10 @@ public class ShellMojo extends AbstractToolsMojo {
                 invokeMethod(setVariable, binding, k, properties.get(k));
             }
         } else {
-            if (groovyOlderThan(GROOVY_4_0_0_RC_1)) {
+            if (groovyOlderThan(GROOVY_4_0_0_RC1)) {
                 invokeMethod(setVariable, binding, "properties", properties);
             } else {
-                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC_1 + " and later.");
+                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
             }
         }
         Object io = invokeConstructor(findConstructor(ioClass));
@@ -158,6 +217,49 @@ public class ShellMojo extends AbstractToolsMojo {
         findField(loggerClass, "io", ioClass).set(null, io);
 
         return invokeConstructor(findConstructor(shellClass, ClassLoader.class, bindingClass, ioClass), classWrangler.getClassLoader(), binding, io);
+    }
+    /**
+     * Executes the Groovy 5 shell.
+     *
+     * @throws MojoExecutionException when a problem occurs during shell execution
+     * @throws ClassNotFoundException when a class needed for shell configuration cannot be found
+     * @throws InvocationTargetException when a reflection invocation needed for shell configuration cannot be completed
+     * @throws IllegalAccessException    when a method needed for shell configuration cannot be accessed
+     */
+    protected void executeGroovy5Shell() throws MojoExecutionException, ClassNotFoundException, InvocationTargetException, IllegalAccessException {
+        try {
+            classWrangler.getClass("org.jline.reader.LineReader");
+        } catch (ClassNotFoundException e) {
+            throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
+        }
+        if (!bindPropertiesToSeparateVariables) {
+            throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
+        }
+        Class<?> mainClass = classWrangler.getClass("org.apache.groovy.groovysh.Main");
+        Method startMethod = null;
+        try {
+            startMethod = findMethod(mainClass, "start", Map.class, String[].class);
+        } catch (IllegalArgumentException e) {
+            // Method not found
+        }
+
+        if (startMethod != null) {
+            Map<String, Object> initialBindings = new HashMap<>();
+            initializeProperties();
+            for (Object k : properties.keySet()) {
+                initialBindings.put((String) k, properties.get(k));
+            }
+
+            ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(classWrangler.getClassLoader());
+                invokeStaticMethod(startMethod, initialBindings, new String[0]);
+            } finally {
+                Thread.currentThread().setContextClassLoader(oldClassLoader);
+            }
+        } else {
+            throw new MojoExecutionException("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support running a shell. The minimum version of Groovy required is " + GROOVY_5_0_4 + ". Skipping shell startup.");
+        }
     }
 
 }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -11,8 +11,9 @@ import org.codehaus.gmavenplus.util.NoExitSecurityManager;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.codehaus.gmavenplus.mojo.ExecuteMojo.GROOVY_4_0_0_RC_1;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findConstructor;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findField;
 import static org.codehaus.gmavenplus.util.ReflectionUtils.findMethod;
@@ -34,9 +35,29 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeStaticMethod;
 public class ShellMojo extends AbstractToolsMojo {
 
     /**
+     * Groovy 2.2.0 beta-1 version.
+     */
+    protected static final Version GROOVY_2_2_0_BETA1 = new Version(2, 2, 0, "beta-1");
+
+    /**
      * Groovy 4.0.0 alpha-1 version.
      */
     protected static final Version GROOVY_4_0_0_ALPHA1 = new Version(4, 0, 0, "alpha-1");
+
+     /**
+      * Groovy 4.0.0 RC-1 version.
+      */
+     protected static final Version GROOVY_4_0_0_RC1 = new Version(4, 0, 0, "RC-1");
+
+    /**
+     * Groovy 5.0.0-beta-2 version.
+     */
+    protected static final Version GROOVY_5_0_0_BETA2 = new Version(5, 0, 0, "beta-2");
+
+    /**
+      * Groovy 5.0.4 version.
+      */
+     protected static final Version GROOVY_5_0_4 = new Version(5, 0, 4);
 
     /**
      * Groovy shell verbosity level. Should be one of:
@@ -90,23 +111,33 @@ public class ShellMojo extends AbstractToolsMojo {
                 }
             }
 
-            // get classes we need with reflection
-            Class<?> shellClass = classWrangler.getClass(groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh.Groovysh" : "org.codehaus.groovy.tools.shell.Groovysh");
-            Class<?> bindingClass = classWrangler.getClass("groovy.lang.Binding");
-            Class<?> ioClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO");
-            Class<?> verbosityClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO$Verbosity");
-            Class<?> loggerClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.util.Logger");
+            if (groovyAtLeast(GROOVY_5_0_0_BETA2)) {
+                executeGroovy5Shell();
+            } else {
+                // get classes we need with reflection
+                Class<?> shellClass = classWrangler.getClass(groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh.Groovysh" : "org.codehaus.groovy.tools.shell.Groovysh");
+                Class<?> bindingClass = classWrangler.getClass("groovy.lang.Binding");
+                Class<?> ioClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO");
+                Class<?> verbosityClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO$Verbosity");
+                Class<?> loggerClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.util.Logger");
 
-            // create shell to run
-            Object shell = setupShell(shellClass, bindingClass, ioClass, verbosityClass, loggerClass);
+                // create shell to run
+                Object shell = setupShell(shellClass, bindingClass, ioClass, verbosityClass, loggerClass);
 
-            // run the shell
-            invokeMethod(findMethod(shellClass, "run", String.class), shell, (String) null);
+                // run the shell
+                invokeMethod(findMethod(shellClass, "run", String.class), shell, (String) null);
+            }
         } catch (ClassNotFoundException e) {
             throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project or the plugin?", e);
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof NoClassDefFoundError && e.getCause().getMessage() != null && e.getCause().getMessage().contains("jline")) {
-                throw new MojoExecutionException("Unable to get a JLine class from classpath. This might be because of a JLine version mismatch. If you are using Groovy < 2.2.0-beta-1, make sure you include JLine 1.0 as a runtime dependency in your project or the plugin.", e);
+                if (groovyAtLeast(GROOVY_5_0_0_BETA2)) {
+                    throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
+                } else if (groovyAtLeast(GROOVY_2_2_0_BETA1)) {
+                    throw new MojoExecutionException("Unable to get a JLine 2 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 2.x as a runtime dependency in your project or the plugin.", e);
+                } else {
+                    throw new MojoExecutionException("Unable to get a JLine 1 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 1.x as a runtime dependency in your project or the plugin.", e);
+                }
             } else {
                 throw new MojoExecutionException("Error occurred while calling a method on a Groovy class from classpath.", e);
             }
@@ -147,10 +178,10 @@ public class ShellMojo extends AbstractToolsMojo {
                 invokeMethod(setVariable, binding, k, properties.get(k));
             }
         } else {
-            if (groovyOlderThan(GROOVY_4_0_0_RC_1)) {
+            if (groovyOlderThan(GROOVY_4_0_0_RC1)) {
                 invokeMethod(setVariable, binding, "properties", properties);
             } else {
-                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC_1 + " and later.");
+                throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
             }
         }
         Object io = invokeConstructor(findConstructor(ioClass));
@@ -158,6 +189,41 @@ public class ShellMojo extends AbstractToolsMojo {
         findField(loggerClass, "io", ioClass).set(null, io);
 
         return invokeConstructor(findConstructor(shellClass, ClassLoader.class, bindingClass, ioClass), classWrangler.getClassLoader(), binding, io);
+    }
+    /**
+     * Executes the Groovy 5 shell.
+     *
+     * @throws MojoExecutionException when a problem occurs during shell execution
+     * @throws ClassNotFoundException when a class needed for shell configuration cannot be found
+     * @throws InvocationTargetException when a reflection invocation needed for shell configuration cannot be completed
+     * @throws IllegalAccessException    when a method needed for shell configuration cannot be accessed
+     */
+    protected void executeGroovy5Shell() throws MojoExecutionException, ClassNotFoundException, InvocationTargetException, IllegalAccessException {
+        Class<?> mainClass = classWrangler.getClass("org.apache.groovy.groovysh.Main");
+        Method startMethod = null;
+        try {
+            startMethod = findMethod(mainClass, "start", Map.class, String[].class);
+        } catch (IllegalArgumentException e) {
+            // Method not found
+        }
+
+        if (startMethod != null) {
+            Map<String, Object> initialBindings = new HashMap<>();
+            initializeProperties();
+            for (Object k : properties.keySet()) {
+                initialBindings.put((String) k, properties.get(k));
+            }
+
+            ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(classWrangler.getClassLoader());
+                invokeStaticMethod(startMethod, initialBindings, new String[0]);
+            } finally {
+                Thread.currentThread().setContextClassLoader(oldClassLoader);
+            }
+        } else {
+            throw new MojoExecutionException("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support running a shell. The minimum version of Groovy required is " + GROOVY_5_0_4 + ". Skipping shell startup.");
+        }
     }
 
 }

--- a/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/ShellMojo.java
@@ -27,6 +27,7 @@ import static org.codehaus.gmavenplus.util.ReflectionUtils.invokeStaticMethod;
  * Note that this mojo requires Groovy &gt;= 1.5.0.
  * Note that it references the plugin ClassLoader to pull in dependencies
  * Groovy didn't include (for things like Ant for AntBuilder, Ivy for @grab, and Jansi for Groovysh).
+ * These dependencies are now optional and must be provided by the user if needed.
  *
  * @author Keegan Witt
  * @since 1.1
@@ -63,6 +64,11 @@ public class ShellMojo extends AbstractToolsMojo {
       * Groovy 5.0.4 version.
       */
      protected static final Version GROOVY_5_0_4 = new Version(5, 0, 4);
+ 
+     /**
+      * Groovy 6.0.0-alpha-1 version.
+      */
+     protected static final Version GROOVY_6_0_0_ALPHA1 = new Version(6, 0, 0, "alpha-1");
 
     /**
      * Groovy shell verbosity level. Should be one of:
@@ -116,22 +122,16 @@ public class ShellMojo extends AbstractToolsMojo {
                 }
             }
 
-            if (groovyAtLeast(GROOVY_5_0_4)) {
-                executeGroovy5Shell();
+            if (groovyAtLeast(GROOVY_5_0_0_BETA2)) {
+                executeModernShell();
             } else {
-                if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
-                    try {
-                        classWrangler.getClass("org.jline.reader.LineReader");
-                    } catch (ClassNotFoundException e) {
-                        throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
-                    }
-                }
                 // get classes we need with reflection
-                Class<?> shellClass = classWrangler.getClass(groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh.Groovysh" : "org.codehaus.groovy.tools.shell.Groovysh");
+                String shellPackage = groovyAtLeast(GROOVY_4_0_0_ALPHA1) ? "org.apache.groovy.groovysh" : "org.codehaus.groovy.tools.shell";
+                Class<?> shellClass = classWrangler.getClass(shellPackage + ".Groovysh");
                 Class<?> bindingClass = classWrangler.getClass("groovy.lang.Binding");
-                Class<?> ioClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO");
-                Class<?> verbosityClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.IO$Verbosity");
-                Class<?> loggerClass = classWrangler.getClass("org.codehaus.groovy.tools.shell.util.Logger");
+                Class<?> ioClass = classWrangler.getClass(shellPackage + ".IO");
+                Class<?> verbosityClass = classWrangler.getClass(shellPackage + ".util.Verbosity");
+                Class<?> loggerClass = classWrangler.getClass(shellPackage + ".util.Logger");
 
                 // create shell to run
                 Object shell = setupShell(shellClass, bindingClass, ioClass, verbosityClass, loggerClass);
@@ -144,7 +144,13 @@ public class ShellMojo extends AbstractToolsMojo {
                     } catch (Exception e) {
                         String message = "Jansi 2.x detected, which is incompatible with JLine 2. Falling back to dumb terminal. Colors will be disabled.";
                         if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
-                            message += " We recommend upgrading to Groovy 5.0.4 or newer for full JLine 3 support.";
+                            message += " To enable colors, use Groovy 5.0.4 or later.";
+                        } else if (groovyOlderThan(GROOVY_5_0_0_ALPHA1)) {
+                            try {
+                                classWrangler.getClass("org.fusesource.jansi.AnsiConsole");
+                            } catch (ClassNotFoundException cnfe) {
+                                message = "Jansi 1.x not found on classpath. Terminal colors will be disabled. To enable them, add org.fusesource.jansi:jansi:1.18 to the plugin's dependencies.";
+                            }
                         }
                         getLog().warn(message);
                         System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
@@ -156,7 +162,7 @@ public class ShellMojo extends AbstractToolsMojo {
             if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
                 throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). This Groovy version (" + classWrangler.getGroovyVersionString() + ") revamped the shell to use JLine 3 and removed some older classes. You might need to use Groovy 5.0.4 or later for full support.", e);
             }
-            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Do you have Groovy as a compile dependency in your project or the plugin?", e);
+            throw new MojoExecutionException("Unable to get a Groovy class from classpath (" + e.getMessage() + "). Ensure groovy-groovysh is on your plugin classpath.", e);
         } catch (InvocationTargetException e) {
             if (e.getCause() instanceof NoClassDefFoundError && e.getCause().getMessage() != null && e.getCause().getMessage().contains("jline")) {
                 if (groovyAtLeast(GROOVY_5_0_0_ALPHA1)) {
@@ -219,21 +225,22 @@ public class ShellMojo extends AbstractToolsMojo {
         return invokeConstructor(findConstructor(shellClass, ClassLoader.class, bindingClass, ioClass), classWrangler.getClassLoader(), binding, io);
     }
     /**
-     * Executes the Groovy 5 shell.
+     * Executes the modern (Groovy 4+) shell.
      *
      * @throws MojoExecutionException when a problem occurs during shell execution
      * @throws ClassNotFoundException when a class needed for shell configuration cannot be found
      * @throws InvocationTargetException when a reflection invocation needed for shell configuration cannot be completed
      * @throws IllegalAccessException    when a method needed for shell configuration cannot be accessed
      */
-    protected void executeGroovy5Shell() throws MojoExecutionException, ClassNotFoundException, InvocationTargetException, IllegalAccessException {
+    protected void executeModernShell() throws MojoExecutionException, ClassNotFoundException, InvocationTargetException, IllegalAccessException {
         try {
             classWrangler.getClass("org.jline.reader.LineReader");
         } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException("Unable to get a JLine 3 class from classpath. This might be because of a JLine version mismatch. Make sure you include JLine 3.x as a runtime dependency in your project or the plugin.", e);
+            String jlineVersion = groovyAtLeast(GROOVY_6_0_0_ALPHA1) ? "4" : "3";
+            getLog().warn("JLine " + jlineVersion + " not found on classpath. Terminal colors and advanced features will be disabled. Ensure groovy-groovysh is on your plugin classpath.");
         }
-        if (!bindPropertiesToSeparateVariables) {
-            throw new IllegalArgumentException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later.");
+        if (!bindPropertiesToSeparateVariables && groovyAtLeast(GROOVY_4_0_0_RC1)) {
+            throw new MojoExecutionException("properties is a read-only property in Groovy " + GROOVY_4_0_0_RC1 + " and later. You must set `bindPropertiesToSeparateVariables` to true.");
         }
         Class<?> mainClass = classWrangler.getClass("org.apache.groovy.groovysh.Main");
         Method startMethod = null;
@@ -244,21 +251,11 @@ public class ShellMojo extends AbstractToolsMojo {
         }
 
         if (startMethod != null) {
-            Map<String, Object> initialBindings = new HashMap<>();
             initializeProperties();
-            for (Object k : properties.keySet()) {
-                initialBindings.put((String) k, properties.get(k));
-            }
-
-            ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
-            try {
-                Thread.currentThread().setContextClassLoader(classWrangler.getClassLoader());
-                invokeStaticMethod(startMethod, initialBindings, new String[0]);
-            } finally {
-                Thread.currentThread().setContextClassLoader(oldClassLoader);
-            }
+            invokeStaticMethod(startMethod, properties, new String[0]);
         } else {
-            throw new MojoExecutionException("Your Groovy version (" + classWrangler.getGroovyVersionString() + ") doesn't support running a shell. The minimum version of Groovy required is " + GROOVY_5_0_4 + ". Skipping shell startup.");
+            getLog().warn("Groovy " + classWrangler.getGroovyVersionString() + " does not support variable bindings in the modern shell path. Starting shell without project context.");
+            invokeStaticMethod(findMethod(mainClass, "main", String[].class), (Object) new String[0]);
         }
     }
 


### PR DESCRIPTION
## Overview

This PR addresses [Issue #381](https://github.com/groovy/GMavenPlus/issues/381), which originally sought to restore `gplus:shell` support for Groovy 6. During implementation, it was discovered that the existing terminal architecture—which relied on a bundled Jansi 1.x library—was fundamentally incompatible with modern Maven environments and the evolving JLine ecosystem in Groovy 5 and 6.

## The Challenges Identified

### 1. The Jansi 1.x vs 2.x Conflict

Historically, GMavenPlus bundled Jansi 1.x to provide terminal colors on Windows. However, **Maven 3.9+** began forcing Jansi 2.x into the core classpath. Because JLine 2 is hardcoded to use Jansi 1.x APIs, this conflict resulted in disabled colors or plugin crashes when running on modern Maven versions.

### 2. JLine Version Fragmentation

Groovy has transitioned through three major versions of JLine across its release lines:

* **Groovy 2.5 - 4.x**: Uses JLine 2 (Legacy).
* **Groovy 5.x**: Uses JLine 3 (Modern).
* **Groovy 6.x**: Uses JLine 4 (Modern).

The previous architecture tried to force all versions through a single legacy path, which broke advanced features and color support in Groovy 5 and 6.

### 3. The "Transitionary" Groovy 5.x Betas

Analysis of Groovy 5.0.0 through 5.0.3 revealed a transitionary state where the old shell APIs were removed but the new `Main.start()` API (required for Maven variable injection) had not yet been finalized.

---

## The Path Forward: The Opt-in Model

To resolve these challenges, #380 introduces a decoupled "Opt-in" dependency model and a dual-path execution engine.

### Key Architectural Changes

1. **Decoupled Dependencies**: GMavenPlus no longer bundles Jansi or JLine. It now relies on the versions provided by the Groovy distribution itself or optional user-provided dependencies.
2. **Dual Execution Paths**:
    * **Modern Path (Groovy 5.0.4+ / 6.x)**: Uses the new `org.apache.groovy.groovysh.Main` entry point, supporting JLine 3/4 and Jansi 2 natively.
    * **Legacy Path (Groovy 2.5 - 4.x)**: Continues to use the reflection-based `Groovysh` engine but with improved conflict detection.
3. **Graceful Degradation**: The plugin now automatically detects Jansi 2.x conflicts. If a conflict is detected and no compatible bridge is found, it falls back to a stable **dumb terminal** experience instead of crashing.

---

## Compatibility Matrix

### 1. Comparison of Behaviors

| Feature | GMavenPlus 4.3.1 (Old) | GMavenPlus 5.0.0 (New) |
| :--- | :--- | :--- |
| **Maven 3.9+ Support** | ❌ Broken Colors | ✅ Supported (via Opt-in) |
| **Groovy 6 Support** | ❌ Broken | ✅ Supported (Out-of-box) |
| **Groovy 5 Support** | ❌ Broken | ✅ Supported (Out-of-box) |
| **Bundled Libraries** | Jansi 1.x (Forced) | None (Clean Classpath) |

### 2. Status by Groovy Version

| Groovy Version | Color Behavior | Status | Requirement |
| :--- | :--- | :--- | :--- |
| **5.0.4+ / 6.x** | ✅ Enabled | **Out of the box** | None (Uses JLine 3/4 transitives). |
| **2.5.x - 4.x** | ✅ Enabled | **Maven < 3.9** | None (Uses JLine 2). |
| **2.5.x - 4.x** | ✅ Enabled | **Maven >= 3.9** | **Opt-in**: Add `org.fusesource.jansi:jansi:1.18`. |
| **5.0.0 - 5.0.3** | ❌ Dumb Term | **Transitionary** | Upgrade to Groovy 5.0.4+. |

---

## Technical Summary

* **Modern Engine**: Leverages `Main.start(Map, String[])` for full project context injection.
* **Legacy Engine**: Uses the `(Binding, IO)` constructor for Groovy 2.5-4.x.
* **Detection Logic**: Uses `classWrangler` to dynamically identify the best available shell engine based on the detected Groovy version and available classpath.
