### PR TITLE
Update Maven and Groovy dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           - 2.5.23
           - 3.0.25
           - 4.0.31
-          - 5.0.5
+          - 5.0.6
     env:
       MVN_GROOVY_GROUP_ID: ${{format('{0}{1}', '-DgroovyVersion=', matrix.groovy-version)}}
       MVN_GROOVY_VERSION: ${{(startsWith(matrix.groovy-version, '2') || startsWith(matrix.groovy-version, '3')) && '-DgroovyGroupId=org.codehaus.groovy' || '-DgroovyGroupId=org.apache.groovy'}}

--- a/pom.xml
+++ b/pom.xml
@@ -11,24 +11,24 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <requiredMavenVersion>3.6.3</requiredMavenVersion>
-    <mavenVersion>3.9.12</mavenVersion>
-    <jacocoPluginVersion>0.8.13</jacocoPluginVersion>
-    <javadocPluginVersion>3.11.2</javadocPluginVersion>
+    <mavenVersion>3.9.16</mavenVersion>
+    <jacocoPluginVersion>0.8.15</jacocoPluginVersion>
+    <javadocPluginVersion>3.12.0</javadocPluginVersion>
     <shortJavaVersion>8</shortJavaVersion>
     <!-- these are properties so integration tests can use them -->
     <javaVersion>1.${shortJavaVersion}</javaVersion>
     <itJavaVersion>11</itJavaVersion>
-    <dependencyPluginVersion>3.8.1</dependencyPluginVersion>
-    <compilerPluginVersion>3.14.0</compilerPluginVersion>
-    <resourcesPluginVersion>3.3.1</resourcesPluginVersion>
+    <dependencyPluginVersion>3.11.0</dependencyPluginVersion>
+    <compilerPluginVersion>3.15.0</compilerPluginVersion>
+    <resourcesPluginVersion>3.5.0</resourcesPluginVersion>
     <junitVersion>4.13.2</junitVersion>
-    <surefirePluginVersion>3.5.3</surefirePluginVersion>
+    <surefirePluginVersion>3.5.4</surefirePluginVersion>
     <pluginPluginVersion>3.15.1</pluginPluginVersion>
     <!-- this is a property so that site generation can use it -->
-    <sourcePluginVersion>3.3.1</sourcePluginVersion>
+    <sourcePluginVersion>3.4.0</sourcePluginVersion>
     <!-- these are properties so that site generation and integration tests can use it -->
     <groovyGroupId>org.apache.groovy</groovyGroupId>
-    <groovyVersion>5.0.5</groovyVersion>
+    <groovyVersion>5.0.6</groovyVersion>
   </properties>
 
   <dependencies>
@@ -82,7 +82,7 @@
       <!-- fix CVE-2024-47554 from org.apache.maven.shared:file-management -->
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>${groovyGroupId}</groupId>
@@ -111,19 +111,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -139,7 +139,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.7</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -164,7 +164,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <goals>
@@ -173,7 +173,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.9.12,)</version>
+                  <version>[${mavenVersion},)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.11,)</version>
@@ -195,14 +195,14 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.10.0</version>
+            <version>1.12.0</version>
           </dependency>
         </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -248,7 +248,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-help-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.5.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -273,7 +273,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.24</version>
+        <version>1.27</version>
         <executions>
           <execution>
             <goals>
@@ -319,12 +319,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <executions>
           <execution>
             <id>integration-test</id>
@@ -432,12 +432,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.7.0</version>
+        <version>0.11.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -462,7 +462,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -484,7 +484,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.9.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -512,7 +512,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>taglist-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.2</version>
         <configuration>
           <tagListOptions>
             <tagClasses>
@@ -532,22 +532,22 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.25.0</version>
+        <version>3.28.0</version>
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.8.6.4</version>
+        <version>4.10.2.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.17.1</version>
+        <version>2.21.0</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/src/it/forkedGroovyDoc/pom.xml
+++ b/src/it/forkedGroovyDoc/pom.xml
@@ -23,13 +23,13 @@
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>4.0.29</version>
+            <version>4.0.31</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-groovydoc</artifactId>
-            <version>4.0.29</version>
+            <version>4.0.31</version>
             <scope>compile</scope>
         </dependency>
   </dependencies>

--- a/src/it/pom.xml
+++ b/src/it/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
     <commonsLang3Version>3.20.0</commonsLang3Version>
-    <junit6Version>6.0.2</junit6Version>
+    <junit6Version>6.1.0</junit6Version>
     <antVersion>1.10.15</antVersion>
     <ivyVersion>2.5.3</ivyVersion>
   </properties>


### PR DESCRIPTION
## Summary

- Upgrade the Maven build API and wrapper distribution alignment to Maven 3.9.16.
- Refresh stable dependencies, build plugins, and integration-test managed versions.
- Keep the published Maven compatibility floor at 3.6.3 and update CI coverage to Groovy 5.0.6.

## Why

The build used an older Maven API version and stale stable dependencies. The Enforcer rule had drifted to the build API version, which would incorrectly require consumers to use Maven 3.9.12 rather than the supported 3.6.3 minimum.

## Impact

Builds use current stable Maven 3-compatible tooling while GMavenPlus continues to advertise and enforce Maven 3.6.3 as its minimum supported runtime.

## Validation

- `./mvnw.cmd --version` (Maven 3.9.16)
- `./mvnw.cmd test` (240 tests passed)
- Full Maven Invoker suite (35 projects passed)
