### PR TITLE
feat: Add `maven.compiler.release` property support

### DIFF
--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -83,6 +83,17 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
     protected String targetBytecode;
 
     /**
+     * The -release version for the Groovy compiler (equivalent to javac's --release).
+     * When set, this takes precedence over targetBytecode.
+     * This allows users to use the modern <code>maven.compiler.release</code> property
+     * instead of <code>maven.compiler.target</code>.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = "maven.compiler.release")
+    protected String release;
+
+    /**
      * Whether to check that the version of Groovy used is able to use the requested <code>targetBytecode</code>.
      *
      * @since 1.9.0
@@ -184,6 +195,21 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
     protected ToolchainManager toolchainManager;
 
     /**
+     * Resolves the target bytecode considering the release property and explicit configuration.
+     * Priority: release (from maven.compiler.release) > targetBytecode (from maven.compiler.target,
+     * explicit config, or default).
+     *
+     * @return the resolved target bytecode value
+     */
+    protected String resolveTargetBytecode() {
+        if (release != null && !release.trim().isEmpty()) {
+            getLog().debug("Using release version " + release + " as target bytecode (from maven.compiler.release).");
+            return release;
+        }
+        return targetBytecode;
+    }
+
+    /**
      * Performs compilation of compile mojos.
      *
      * @param sources                the sources to compile
@@ -216,7 +242,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         configuration.setParameters(parameters);
         configuration.setPreviewFeatures(previewFeatures);
         configuration.setSourceEncoding(sourceEncoding);
-        configuration.setTargetBytecode(targetBytecode);
+        configuration.setTargetBytecode(resolveTargetBytecode());
 
         Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
         if (toolchain != null) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -81,6 +81,17 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected String targetBytecode;
 
     /**
+     * The -release version for the Groovy compiler (equivalent to javac's --release).
+     * When set, this takes precedence over targetBytecode.
+     * This allows users to use the modern <code>maven.compiler.release</code> property
+     * instead of <code>maven.compiler.target</code>.
+     *
+     * @since 5.0.1
+     */
+    @Parameter(property = "maven.compiler.release")
+    protected String release;
+
+    /**
      * Whether to check that the version of Groovy used is able to use the requested <code>targetBytecode</code>.
      *
      * @since 1.9.0
@@ -149,6 +160,21 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
     protected org.apache.maven.execution.MavenSession session;
 
     /**
+     * Resolves the target bytecode considering the release property and explicit configuration.
+     * Priority: release (from maven.compiler.release) > targetBytecode (from maven.compiler.target,
+     * explicit config, or default).
+     *
+     * @return the resolved target bytecode value
+     */
+    protected String resolveTargetBytecode() {
+        if (release != null && !release.trim().isEmpty()) {
+            getLog().debug("Using release version " + release + " as target bytecode (from maven.compiler.release).");
+            return release;
+        }
+        return targetBytecode;
+    }
+
+    /**
      * Performs the stub generation on the specified source files.
      *
      * @param stubSources     the sources to perform stub generation on
@@ -174,7 +200,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
         configuration.setWarningLevel(warningLevel);
         configuration.setTolerance(tolerance);
         configuration.setSourceEncoding(sourceEncoding);
-        configuration.setTargetBytecode(targetBytecode);
+        configuration.setTargetBytecode(resolveTargetBytecode());
 
         org.apache.maven.toolchain.Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
         if (toolchain != null) {

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojoTest.java
@@ -6,8 +6,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -35,6 +37,37 @@ public class AbstractCompileMojoTest {
     public void testGroovyVersionSupportsActionFalse() {
         testMojo = new TestMojo("1.1-rc-3");
         assertFalse(testMojo.groovyVersionSupportsAction());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsNullWhenBothUnset() {
+        assertNull(testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsTargetBytecodeWhenNoRelease() {
+        testMojo.targetBytecode = "11";
+        assertEquals("11", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsTargetBytecodeWhenReleaseIsBlank() {
+        testMojo.targetBytecode = "11";
+        testMojo.release = "   ";
+        assertEquals("11", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsReleaseWhenSet() {
+        testMojo.release = "17";
+        assertEquals("17", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReleaseTakesPrecedence() {
+        testMojo.release = "21";
+        testMojo.targetBytecode = "1.8";
+        assertEquals("21", testMojo.resolveTargetBytecode());
     }
 
     protected static class TestMojo extends AbstractCompileMojo {

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojoTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -69,6 +70,37 @@ public class AbstractGenerateStubsMojoTest {
     public void testGroovyVersionSupportsActionFalse() {
         testMojo = new TestMojo("1.1-rc-3");
         assertFalse(testMojo.groovyVersionSupportsAction());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsNullWhenBothUnset() {
+        assertNull(testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsTargetBytecodeWhenNoRelease() {
+        testMojo.targetBytecode = "11";
+        assertEquals("11", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsTargetBytecodeWhenReleaseIsBlank() {
+        testMojo.targetBytecode = "11";
+        testMojo.release = "   ";
+        assertEquals("11", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReturnsReleaseWhenSet() {
+        testMojo.release = "17";
+        assertEquals("17", testMojo.resolveTargetBytecode());
+    }
+
+    @Test
+    public void testResolveTargetBytecodeReleaseTakesPrecedence() {
+        testMojo.release = "21";
+        testMojo.targetBytecode = "1.8";
+        assertEquals("21", testMojo.resolveTargetBytecode());
     }
 
     @Test


### PR DESCRIPTION
GMavenPlus currently ignores the `maven.compiler.release` Maven property, always falling back to bytecode level `1.8` when neither `targetBytecode` nor `maven.compiler.target` are set. This breaks compilation with Groovy 5+, which requires Java 9+ bytecode.

## Changes

- Added `@Parameter(property = "maven.compiler.release") String release` field to both `AbstractCompileMojo` and `AbstractGenerateStubsMojo`
- Added `resolveTargetBytecode()` method with priority: `release` > `targetBytecode` (explicit config > `maven.compiler.target` > default `1.8`)
- Updated `doCompile()` / `doStubGeneration()` to call `resolveTargetBytecode()` instead of reading `targetBytecode` directly
- Added 10 unit tests (5 per mojo) covering all resolution paths

## Resolution priority

1. `release` (from `maven.compiler.release` property)
2. `targetBytecode` (explicit `<targetBytecode>` config in POM)
3. Falls through to existing default behavior

Closes #387
