### PR TITLE
feat: Honor compiler release for Groovy bytecode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.codehaus.gmavenplus</groupId>
   <artifactId>gmavenplus-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractCompileMojo.java
@@ -78,8 +78,10 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
      * Using 23 requires Groovy &gt; 4.0.21 or Groovy &gt; 5.0.0-alpha-8.
      * Using 24 requires Groovy &gt; 4.0.24 or Groovy &gt; 5.0.0-alpha-11.
      * Using 25 requires Groovy &gt; 4.0.27 or Groovy &gt; 5.0.0-alpha-13.
+     * If unset, this uses <code>maven.compiler.release</code>, then <code>maven.compiler.target</code>,
+     * then <code>1.8</code>.
      */
-    @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
+    @Parameter
     protected String targetBytecode;
 
     /**
@@ -216,7 +218,7 @@ public abstract class AbstractCompileMojo extends AbstractGroovySourcesMojo {
         configuration.setParameters(parameters);
         configuration.setPreviewFeatures(previewFeatures);
         configuration.setSourceEncoding(sourceEncoding);
-        configuration.setTargetBytecode(targetBytecode);
+        configuration.setTargetBytecode(resolveTargetBytecode(targetBytecode));
 
         Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
         if (toolchain != null) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGenerateStubsMojo.java
@@ -74,10 +74,12 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
      * Using 23 requires Groovy &gt; 4.0.21 or Groovy &gt; 5.0.0-alpha-8.
      * Using 24 requires Groovy &gt; 4.0.24 or Groovy &gt; 5.0.0-alpha-11.
      * Using 25 requires Groovy &gt; 4.0.27 or Groovy &gt; 5.0.0-alpha-13.
+     * If unset, this uses <code>maven.compiler.release</code>, then <code>maven.compiler.target</code>,
+     * then <code>1.8</code>.
      *
      * @since 1.0-beta-3
      */
-    @Parameter(property = "maven.compiler.target", defaultValue = "1.8")
+    @Parameter
     protected String targetBytecode;
 
     /**
@@ -174,7 +176,7 @@ public abstract class AbstractGenerateStubsMojo extends AbstractGroovyStubSource
         configuration.setWarningLevel(warningLevel);
         configuration.setTolerance(tolerance);
         configuration.setSourceEncoding(sourceEncoding);
-        configuration.setTargetBytecode(targetBytecode);
+        configuration.setTargetBytecode(resolveTargetBytecode(targetBytecode));
 
         org.apache.maven.toolchain.Toolchain toolchain = toolchainManager.getToolchainFromBuildContext("jdk", session);
         if (toolchain != null) {

--- a/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
+++ b/src/main/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojo.java
@@ -10,10 +10,12 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.codehaus.gmavenplus.model.IncludeClasspath;
 import org.codehaus.gmavenplus.model.internal.Version;
 import org.codehaus.gmavenplus.util.ClassWrangler;
+import org.codehaus.gmavenplus.util.GroovyCompiler;
 
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Properties;
 
 import static java.util.Collections.emptyList;
 
@@ -34,6 +36,12 @@ public abstract class AbstractGroovyMojo extends AbstractMojo {
      * The pattern defining Java stub files.
      */
     protected static final String JAVA_SOURCES_PATTERN = "**" + File.separator + "*.java";
+
+    protected static final String DEFAULT_TARGET_BYTECODE = "1.8";
+
+    private static final String MAVEN_COMPILER_RELEASE = "maven.compiler.release";
+
+    private static final String MAVEN_COMPILER_TARGET = "maven.compiler.target";
 
     /**
      * Java 1.7 version.
@@ -216,6 +224,41 @@ public abstract class AbstractGroovyMojo extends AbstractMojo {
      */
     protected boolean isGroovyIndy() {
         return classWrangler.isGroovyIndy();
+    }
+
+    protected static String resolveTargetBytecode(String targetBytecode, String release, String compilerTarget) {
+        if (!isBlank(targetBytecode)) {
+            return targetBytecode;
+        } else if (!isBlank(release)) {
+            return GroovyCompiler.translateJavacTargetToTargetBytecode(release);
+        } else if (!isBlank(compilerTarget)) {
+            return GroovyCompiler.translateJavacTargetToTargetBytecode(compilerTarget);
+        }
+        return DEFAULT_TARGET_BYTECODE;
+    }
+
+    protected String resolveTargetBytecode(String targetBytecode) {
+        return resolveTargetBytecode(targetBytecode, getMavenProperty(MAVEN_COMPILER_RELEASE), getMavenProperty(MAVEN_COMPILER_TARGET));
+    }
+
+    private String getMavenProperty(String propertyName) {
+        String propertyValue = getProperty(session != null ? session.getUserProperties() : null, propertyName);
+        if (!isBlank(propertyValue)) {
+            return propertyValue;
+        }
+        propertyValue = getProperty(session != null ? session.getSystemProperties() : null, propertyName);
+        if (!isBlank(propertyValue)) {
+            return propertyValue;
+        }
+        return getProperty(project != null ? project.getProperties() : null, propertyName);
+    }
+
+    private static String getProperty(Properties properties, String propertyName) {
+        return properties != null ? properties.getProperty(propertyName) : null;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     /**

--- a/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/AbstractGroovyMojoTest.java
@@ -1,13 +1,19 @@
 package org.codehaus.gmavenplus.mojo;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.gmavenplus.model.internal.Version;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.util.Properties;
+
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-
 
 /**
  * Unit tests for the AbstractGroovyMojo class.
@@ -50,6 +56,108 @@ public class AbstractGroovyMojoTest {
     public void testIsJavaSupportPreviewFeaturesNo() {
         doReturn(Version.parseFromString("11.0.3")).when(testMojo).getJavaVersion();
         assertFalse(testMojo.isJavaSupportPreviewFeatures());
+    }
+
+    @Test
+    public void testTargetBytecodeWinsOverRelease() {
+        assertEquals("11", TestGroovyMojo.resolveTargetBytecode("11", "17", "21"));
+    }
+
+    @Test
+    public void testReleaseIsUsedWhenTargetBytecodeIsUnset() {
+        assertEquals("17", TestGroovyMojo.resolveTargetBytecode(null, "17", "21"));
+    }
+
+    @Test
+    public void testReleaseWinsOverMavenCompilerTarget() {
+        assertEquals("17", TestGroovyMojo.resolveTargetBytecode(null, "17", "11"));
+    }
+
+    @Test
+    public void testMavenCompilerTargetIsUsedWhenTargetBytecodeAndReleaseAreUnset() {
+        assertEquals("11", TestGroovyMojo.resolveTargetBytecode(null, null, "11"));
+    }
+
+    @Test
+    public void testReleaseIsTranslatedFromJavacTargetFormat() {
+        assertEquals("1.8", TestGroovyMojo.resolveTargetBytecode(null, "8", null));
+    }
+
+    @Test
+    public void testMavenCompilerTargetIsTranslatedFromJavacTargetFormat() {
+        assertEquals("1.8", TestGroovyMojo.resolveTargetBytecode(null, null, "8"));
+    }
+
+    @Test
+    public void testDefaultTargetBytecodeIsUsedWhenTargetBytecodeAndReleaseAreUnset() {
+        assertEquals("1.8", TestGroovyMojo.resolveTargetBytecode(null, null, null));
+    }
+
+    @Test
+    public void testBlankTargetBytecodeFallsBackToRelease() {
+        assertEquals("17", TestGroovyMojo.resolveTargetBytecode(" ", "17", "21"));
+    }
+
+    @Test
+    public void testMavenCompilerPropertiesAreNotExposedAsMojoParameters() {
+        assertFalse(isMojoParameter(AbstractCompileMojo.class, "release"));
+        assertFalse(isMojoParameter(AbstractCompileMojo.class, "compilerRelease"));
+        assertFalse(isMojoParameter(AbstractCompileMojo.class, "compilerTarget"));
+        assertFalse(isMojoParameter(AbstractGenerateStubsMojo.class, "release"));
+        assertFalse(isMojoParameter(AbstractGenerateStubsMojo.class, "compilerRelease"));
+        assertFalse(isMojoParameter(AbstractGenerateStubsMojo.class, "compilerTarget"));
+    }
+
+    @Test
+    public void testResolveTargetBytecodeUsesMavenProperties() {
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.release", "17");
+        projectProperties.setProperty("maven.compiler.target", "11");
+        testMojo.project = mock(MavenProject.class);
+        doReturn(projectProperties).when(testMojo.project).getProperties();
+
+        assertEquals("17", testMojo.resolveTargetBytecode(null));
+    }
+
+    @Test
+    public void testResolveTargetBytecodeUsesUserPropertyBeforeSystemAndProjectProperties() {
+        Properties userProperties = new Properties();
+        userProperties.setProperty("maven.compiler.release", "23");
+        Properties systemProperties = new Properties();
+        systemProperties.setProperty("maven.compiler.release", "21");
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.release", "17");
+        testMojo.session = mock(MavenSession.class);
+        doReturn(userProperties).when(testMojo.session).getUserProperties();
+        doReturn(systemProperties).when(testMojo.session).getSystemProperties();
+        testMojo.project = mock(MavenProject.class);
+        doReturn(projectProperties).when(testMojo.project).getProperties();
+
+        assertEquals("23", testMojo.resolveTargetBytecode(null));
+    }
+
+    @Test
+    public void testResolveTargetBytecodeUsesSystemPropertyBeforeProjectProperty() {
+        Properties systemProperties = new Properties();
+        systemProperties.setProperty("maven.compiler.release", "21");
+        Properties projectProperties = new Properties();
+        projectProperties.setProperty("maven.compiler.release", "17");
+        testMojo.session = mock(MavenSession.class);
+        doReturn(new Properties()).when(testMojo.session).getUserProperties();
+        doReturn(systemProperties).when(testMojo.session).getSystemProperties();
+        testMojo.project = mock(MavenProject.class);
+        doReturn(projectProperties).when(testMojo.project).getProperties();
+
+        assertEquals("21", testMojo.resolveTargetBytecode(null));
+    }
+
+    private static boolean isMojoParameter(Class<?> mojoClass, String fieldName) {
+        try {
+            Field field = mojoClass.getDeclaredField(fieldName);
+            return field.isAnnotationPresent(Parameter.class);
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
     }
 
     public static class TestGroovyMojo extends AbstractGroovyMojo {

--- a/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/CompileMojoTest.java
@@ -5,16 +5,22 @@ import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.gmavenplus.model.GroovyCompileConfiguration;
 import org.codehaus.gmavenplus.model.internal.Version;
 import org.codehaus.gmavenplus.util.ClassWrangler;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
+import java.util.Collections;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -44,6 +50,7 @@ public class CompileMojoTest {
         doReturn(true).when(compileMojo).groovyVersionSupportsAction();
         compileMojo.classWrangler = mock(ClassWrangler.class);
         doReturn(new Version(1, 5, 0)).when(compileMojo.classWrangler).getGroovyVersion();
+        compileMojo.toolchainManager = mock(ToolchainManager.class);
     }
 
     @Test
@@ -103,6 +110,23 @@ public class CompileMojoTest {
         compileMojo.classWrangler = mock(ClassWrangler.class);
         doReturn(new Version(1, 0)).when(compileMojo.classWrangler).getGroovyVersion();
         assertFalse(compileMojo.groovyVersionSupportsAction());
+    }
+
+    @Test
+    public void testReleaseWinsOverCompilerTargetWhenSettingCompileTargetBytecode() throws Exception {
+        Set<File> sources = new TreeSet<>();
+        sources.add(mock(File.class));
+        Properties properties = new Properties();
+        properties.setProperty("maven.compiler.release", "17");
+        properties.setProperty("maven.compiler.target", "11");
+        doReturn(properties).when(compileMojo.project).getProperties();
+        doNothing().when(compileMojo).performInProcessCompilation(any(GroovyCompileConfiguration.class), anyList());
+
+        compileMojo.doCompile(sources, Collections.emptyList(), mock(File.class));
+
+        ArgumentCaptor<GroovyCompileConfiguration> configurationCaptor = ArgumentCaptor.forClass(GroovyCompileConfiguration.class);
+        verify(compileMojo).performInProcessCompilation(configurationCaptor.capture(), anyList());
+        Assert.assertEquals("17", configurationCaptor.getValue().getTargetBytecode());
     }
 
 }

--- a/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
+++ b/src/test/java/org/codehaus/gmavenplus/mojo/GenerateStubsMojoTest.java
@@ -5,16 +5,23 @@ import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.model.fileset.FileSet;
+import org.apache.maven.toolchain.ToolchainManager;
+import org.codehaus.gmavenplus.model.GroovyStubConfiguration;
 import org.codehaus.gmavenplus.model.internal.Version;
 import org.codehaus.gmavenplus.util.ClassWrangler;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertFalse;
@@ -41,6 +48,7 @@ public class GenerateStubsMojoTest {
         doReturn(mock(Build.class)).when(generateStubsMojo.project).getBuild();
         generateStubsMojo.classWrangler = mock(ClassWrangler.class);
         doReturn(new Version(1, 8, 2)).when(generateStubsMojo.classWrangler).getGroovyVersion();
+        generateStubsMojo.toolchainManager = mock(ToolchainManager.class);
     }
 
     @Test
@@ -102,6 +110,23 @@ public class GenerateStubsMojoTest {
     public void testGroovyVersionSupportsActionFalse() {
         doReturn(Version.parseFromString("1.0")).when(generateStubsMojo.classWrangler).getGroovyVersion();
         assertFalse(generateStubsMojo.groovyVersionSupportsAction());
+    }
+
+    @Test
+    public void testReleaseWinsOverCompilerTargetWhenSettingStubTargetBytecode() throws Exception {
+        Set<File> sources = new TreeSet<>();
+        sources.add(mock(File.class));
+        Properties properties = new Properties();
+        properties.setProperty("maven.compiler.release", "17");
+        properties.setProperty("maven.compiler.target", "11");
+        doReturn(properties).when(generateStubsMojo.project).getProperties();
+        doNothing().when(generateStubsMojo).performInProcessStubGeneration(any(GroovyStubConfiguration.class), anyList());
+
+        generateStubsMojo.doStubGeneration(sources, Collections.emptyList(), mock(File.class));
+
+        ArgumentCaptor<GroovyStubConfiguration> configurationCaptor = ArgumentCaptor.forClass(GroovyStubConfiguration.class);
+        verify(generateStubsMojo).performInProcessStubGeneration(configurationCaptor.capture(), anyList());
+        Assert.assertEquals("17", configurationCaptor.getValue().getTargetBytecode());
     }
 
 }


### PR DESCRIPTION
Honor `maven.compiler.release` when deriving Groovy bytecode target configuration.

When `targetBytecode` is not configured directly, compile and stub generation now prefer `maven.compiler.release`, then fall back to `maven.compiler.target`, and finally the existing `1.8` default. This keeps Groovy classfile output aligned with Maven Compiler Plugin release-based Java builds without treating GroovyDoc as a bytecode-producing path.

**Version Bump**

Bump the plugin snapshot version to `5.1.0-SNAPSHOT` for this behavior change.

Fixes #387